### PR TITLE
Phase 0 infra: Redis, docker-compose, CI pipeline, app/ module scaffolding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,11 @@
 # app/ (Postgres modular monolith)
 DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/car_aggregator
+REDIS_URL=redis://localhost:6379/0
+
+# used by docker-compose to configure the postgres service itself
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+POSTGRES_DB=car_aggregator
 
 # legacy PoC (mongo/, api.py, main.py) — unaffected, still Mongo-backed
 MONGODB_URL=mongodb://localhost:27017

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install -r requirements-dev.txt
+
+      - name: Lint (ruff)
+        run: ruff check .
+
+      - name: Type check (mypy)
+        run: mypy app
+
+      - name: Unit tests
+        run: pytest
+
+      - name: Build Docker image
+        run: docker build -t car-ad-scraper:ci .

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,6 @@
+"""Postgres-backed modular monolith (see the legacy Mongo PoC at repo root, left untouched).
+
+Dependency direction: API (app/api/) -> Application (per-domain packages: listings, search,
+market, ...) -> Domain (app/models/) -> Infrastructure (app/db/, app/infrastructure/, app/sources/).
+Higher layers may import lower ones, never the reverse.
+"""

--- a/app/admin/__init__.py
+++ b/app/admin/__init__.py
@@ -1,0 +1,1 @@
+"""Not started — no model or routes exist yet."""

--- a/app/auth/__init__.py
+++ b/app/auth/__init__.py
@@ -1,0 +1,1 @@
+"""Not started — session/token strategy is an open architecture question (cookie vs JWT)."""

--- a/app/billing/__init__.py
+++ b/app/billing/__init__.py
@@ -1,0 +1,1 @@
+"""No entitlement enforcement yet — model is app.models.subscription.SubscriptionPlan (schema only)."""

--- a/app/config.py
+++ b/app/config.py
@@ -7,6 +7,7 @@ class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 
     database_url: str = "postgresql+asyncpg://postgres:postgres@localhost:5432/car_aggregator"
+    redis_url: str = "redis://localhost:6379/0"
     cors_origins: list[str] = [
         "http://localhost:63342",
         "http://0.0.0.0:8000",

--- a/app/infrastructure/__init__.py
+++ b/app/infrastructure/__init__.py
@@ -1,0 +1,1 @@
+"""Cross-cutting infrastructure clients (Redis, ...) shared by every domain module."""

--- a/app/infrastructure/redis.py
+++ b/app/infrastructure/redis.py
@@ -1,0 +1,19 @@
+"""Shared Redis client. Cache/lock/queue-adjacent use only — never the source of truth for
+business-critical data (that's Postgres, see app/db/).
+
+Deliberately just a client factory: redis-py's own Redis.lock() and list commands already cover
+locks and simple queues, and the actual job-queue library (ARQ/Celery/RQ) is an open decision
+(see the "Decide open architecture questions" issue) — no point building a bespoke wrapper ahead
+of that choice.
+"""
+
+from functools import lru_cache
+
+from redis.asyncio import Redis
+
+from app.config import get_settings
+
+
+@lru_cache
+def get_redis() -> Redis:
+    return Redis.from_url(get_settings().redis_url, decode_responses=True)

--- a/app/market/__init__.py
+++ b/app/market/__init__.py
@@ -1,0 +1,1 @@
+"""Not started — market price calculation (median/trimmed quantiles) is a later phase."""

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,14 +1,14 @@
 """Import every model module so `Base.metadata` (and Alembic autogenerate) sees all tables."""
 
-from app.models.source import Source
-from app.models.vehicle import Generation
 from app.models.listing import Listing, ListingStatus
-from app.models.snapshot import ListingSnapshot
-from app.models.user import User
+from app.models.notification import Notification, NotificationType
 from app.models.saved_search import SavedSearch
 from app.models.scrape_job import ScrapeJob, ScrapeJobStatus, ScrapeJobType
-from app.models.notification import Notification, NotificationType
+from app.models.snapshot import ListingSnapshot
+from app.models.source import Source
 from app.models.subscription import SubscriptionPlan, UserSubscription
+from app.models.user import User
+from app.models.vehicle import Generation
 
 __all__ = [
     "Source",

--- a/app/notifications/__init__.py
+++ b/app/notifications/__init__.py
@@ -1,0 +1,1 @@
+"""No delivery (email/in-app) yet — model is app.models.notification.Notification (schema only)."""

--- a/app/saved_searches/__init__.py
+++ b/app/saved_searches/__init__.py
@@ -1,0 +1,1 @@
+"""No service/repository/routes yet — model is app.models.saved_search.SavedSearch (schema only)."""

--- a/app/search/service.py
+++ b/app/search/service.py
@@ -139,15 +139,20 @@ class SearchService:
         )
 
     async def _search_grouped(self, request: SearchRequest) -> SearchResponse:
-        unknown = set(request.group_by) - ALLOWED_GROUP_FIELDS.keys()
+        group_by = request.group_by
+        assert group_by, "search() only calls _search_grouped when group_by is truthy"
+
+        unknown = set(group_by) - ALLOWED_GROUP_FIELDS.keys()
         if unknown:
             raise HTTPException(status_code=400, detail=f"Invalid group_by fields: {sorted(unknown)}")
 
-        group_columns = [ALLOWED_GROUP_FIELDS[field] for field in request.group_by]
+        group_columns = [ALLOWED_GROUP_FIELDS[field] for field in group_by]
 
         stmt = select(
             *group_columns,
-            func.count(Listing.id).label("count"),
+            # Labeled "group_count", not "count" — Row already has a real `.count` (from tuple),
+            # so attribute access on a "count"-labeled column would shadow it.
+            func.count(Listing.id).label("group_count"),
             func.min(Listing.price).label("price_min"),
             func.avg(Listing.price).label("price_avg"),
             func.max(Listing.price).label("price_max"),
@@ -179,14 +184,14 @@ class SearchService:
         groups: list[ListingGroupOut] = []
         total_listings = 0
         for row in rows:
-            total_listings += row.count
+            total_listings += row.group_count
         for row in page_rows:
-            group = {field: getattr(row, field) for field in request.group_by}
+            group = {field: getattr(row, field) for field in group_by}
             groups.append(
                 ListingGroupOut(
                     group=group,
                     label=_build_label(group),
-                    count=row.count,
+                    count=row.group_count,
                     currency="EUR",
                     price_min=row.price_min,
                     price_avg=round(row.price_avg),

--- a/app/sources/polovniautomobili/adapter.py
+++ b/app/sources/polovniautomobili/adapter.py
@@ -12,7 +12,7 @@ from urllib.parse import urlencode
 import requests
 
 from app.search.query import SearchQuery
-from app.sources.base import SourceListingRef, SourceListing
+from app.sources.base import SourceListing, SourceListingRef
 from app.sources.polovniautomobili.mapper import BASE_URL, map_product_data, map_search_result, normalize_fuel_type
 from scraping.translation import fuel_type_codes
 from scraping.utilities import default_request_headers

--- a/app/users/__init__.py
+++ b/app/users/__init__.py
@@ -1,0 +1,1 @@
+"""No service/repository/routes yet — model is app.models.user.User (schema only)."""

--- a/app/vehicles/__init__.py
+++ b/app/vehicles/__init__.py
@@ -1,0 +1,1 @@
+"""No service/repository/routes yet — models are app.models.vehicle.CanonicalVehicle/Generation."""

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   frontend:
     build:
@@ -20,6 +19,20 @@ services:
     depends_on:
       - mongodb
 
+  # New Postgres-backed app/ (search API v1). Runs alongside the legacy `backend` service above,
+  # not replacing it — `backend` is still what's actually deployed.
+  api:
+    build:
+      context: .
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8001
+    ports:
+      - "8001:8001"
+    environment:
+      DATABASE_URL: "postgresql+asyncpg://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres:5432/${POSTGRES_DB:-car_aggregator}"
+      REDIS_URL: "redis://redis:6379/0"
+    depends_on:
+      - postgres
+      - redis
 
   mongodb:
     image: mongo
@@ -33,11 +46,16 @@ services:
     ports:
       - "5432:5432"
     environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
-      POSTGRES_DB: car_aggregator
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_DB: ${POSTGRES_DB:-car_aggregator}
     volumes:
       - postgres_data:/var/lib/postgresql/data
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
 
 volumes:
   mongo_data:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[tool.ruff]
+line-length = 120
+extend-exclude = ["mongo", "scraping", "parsers", "frontend", "api.py", "main.py", "migrations"]
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP"]
+
+[tool.mypy]
+python_version = "3.12"
+ignore_missing_imports = true
+exclude = ["mongo", "scraping", "parsers", "frontend", "api.py", "main.py", "migrations"]
+
+# app/sources/polovniautomobili/adapter.py still imports the legacy scraping/ package (see #10,
+# fetch-strategy abstraction — separately tracked). `exclude` only skips it as an entry point;
+# this stops mypy from also reporting on it when followed as an import.
+[[tool.mypy.overrides]]
+module = "scraping.*"
+ignore_errors = true

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+ruff
+mypy

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ pytest
 pytest-asyncio
 aiosqlite
 greenlet
+redis>=5.0

--- a/tests/unit/test_polovni_adapter.py
+++ b/tests/unit/test_polovni_adapter.py
@@ -22,8 +22,8 @@ def test_parse_search_page_extracts_normalized_listings():
     assert first.production_year > 1990
     assert first.canonical_url.startswith("https://www.polovniautomobili.com/auto-oglasi/")
     # fuel/transmission/body normalized to the mapper's canonical vocabulary, not raw Serbian text
-    assert all(l.fuel_type in {"diesel", "petrol", "hybrid", "electric", "lpg", "cng", None} for l in listings)
-    assert all(l.transmission in {"automatic", "manual", None} for l in listings)
+    assert all(x.fuel_type in {"diesel", "petrol", "hybrid", "electric", "lpg", "cng", None} for x in listings)
+    assert all(x.transmission in {"automatic", "manual", None} for x in listings)
 
 
 def test_parse_listing_extracts_full_detail():

--- a/tests/unit/test_redis_client.py
+++ b/tests/unit/test_redis_client.py
@@ -1,0 +1,12 @@
+from app.infrastructure.redis import get_redis
+
+
+def test_get_redis_uses_configured_url():
+    kwargs = get_redis().connection_pool.connection_kwargs
+    assert kwargs["host"] == "localhost"
+    assert kwargs["port"] == 6379
+    assert kwargs["db"] == 0
+
+
+def test_get_redis_is_cached():
+    assert get_redis() is get_redis()


### PR DESCRIPTION
## Summary
- Redis client factory (`app/infrastructure/redis.py`), configured via `REDIS_URL` / `.env` — cache/lock/queue-adjacent use only, not a business-data store
- `docker-compose.yaml`: new `redis` service; new `api` service running the Postgres-backed `app/` (alongside the existing legacy `backend`, which is unchanged); Postgres credentials moved from hardcoded values to `.env`-sourced vars
- GitHub Actions CI (`.github/workflows/ci.yml`): ruff → mypy → pytest → `docker build` on every push/PR, backed by a new `pyproject.toml` (ruff+mypy config, scoped to `app/`+`tests/`, legacy PoC excluded) and `requirements-dev.txt`
- Missing domain package stubs added under `app/` (`auth`, `users`, `vehicles`, `market`, `saved_searches`, `notifications`, `billing`, `admin`) per the target modular-monolith layout, each a one-line docstring pointing at its existing schema-only model
- Along the way, mypy caught a real footgun in grouped search: the SQL label `"count"` shadowed `Row`'s inherited `tuple.count` method on attribute access — relabeled to `group_count` (public `ListingGroupOut.count` field unchanged)

Verified locally: `ruff check .` / `mypy app` / `pytest` (9/9) all clean; `docker build .` succeeds; full `docker compose up postgres redis api` + `alembic upgrade head` + a live `POST /api/v1/search` all worked end-to-end.

## Issues

Closes:
- Closes #6 — Redis for queue/cache/locks foundation
- Closes #3 — docker-compose for local development
- Closes #8 — basic CI pipeline (lint, type-check, unit tests, build)

Relates to (groundwork only):
- Relates to #2 — missing domain packages scaffolded, but `app/models/*.py` stays a shared cross-cutting module rather than being split per-domain (too large a blast radius for foundation-only infra work); dependency direction documented as a docstring in `app/__init__.py`
- Relates to #3 — `worker`/`scheduler` services and `minio`/S3 intentionally **not** added: no queue library chosen yet (that's #59) and nothing in the app touches object storage, so there's no process/config to containerize

Explicitly out of scope for this PR (per architecture dependencies, discussed with the repo owner):
- #59 (open architecture decisions), #7 (auth — blocked on #59's session-strategy decision), #55 (security hardening — blocked on #7), #58 (staging/prod deploy — needs real cloud credentials)

## Test plan
- [x] `ruff check .` (clean)
- [x] `mypy app` (clean)
- [x] `pytest` (9/9 passing)
- [x] `docker build .`
- [x] `docker compose up postgres redis api` + `alembic upgrade head` + live `POST /api/v1/search` → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)