### PR TITLE
Implement authentication (cookie + Redis sessions)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,14 @@
 DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:5432/car_aggregator
 REDIS_URL=redis://localhost:6379/0
 
+# Auth cookies — set COOKIE_SECURE=true once served over https
+COOKIE_SECURE=false
+FRONTEND_BASE_URL=http://localhost:3000
+
+# Transactional email (Resend). Leave blank to use the logging-only sender (local dev/CI default).
+RESEND_API_KEY=
+EMAIL_FROM_ADDRESS=onboarding@resend.dev
+
 # used by docker-compose to configure the postgres service itself
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres

--- a/app/api/v1/auth.py
+++ b/app/api/v1/auth.py
@@ -1,0 +1,139 @@
+from fastapi import APIRouter, Depends, Request, Response
+from redis.asyncio import Redis
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.dependencies import get_current_user, require_csrf
+from app.auth.email import EmailSender, get_email_sender
+from app.auth.schemas import (
+    ForgotPasswordRequest,
+    LoginRequest,
+    MessageOut,
+    RegisterRequest,
+    ResetPasswordRequest,
+    UserOut,
+    VerifyEmailRequest,
+)
+from app.auth.service import AuthService
+from app.auth.tokens import generate_token
+from app.config import get_settings
+from app.db.session import get_session
+from app.infrastructure.redis import get_redis
+from app.models.user import User
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+me_router = APIRouter(tags=["me"])
+
+
+def _get_auth_service(
+    session: AsyncSession = Depends(get_session),
+    redis: Redis = Depends(get_redis),
+    email_sender: EmailSender = Depends(get_email_sender),
+) -> AuthService:
+    return AuthService(session, redis, email_sender)
+
+
+def _set_auth_cookies(response: Response, session_id: str) -> None:
+    settings = get_settings()
+    csrf_token = generate_token()
+    response.set_cookie(
+        settings.session_cookie_name,
+        session_id,
+        max_age=settings.session_ttl_seconds,
+        path="/",
+        secure=settings.cookie_secure,
+        httponly=True,
+        samesite="lax",
+    )
+    # Not HttpOnly — the SPA must be able to read it to echo it back as X-CSRF-Token.
+    response.set_cookie(
+        settings.csrf_cookie_name,
+        csrf_token,
+        max_age=settings.session_ttl_seconds,
+        path="/",
+        secure=settings.cookie_secure,
+        httponly=False,
+        samesite="lax",
+    )
+
+
+def _clear_auth_cookies(response: Response) -> None:
+    settings = get_settings()
+    response.delete_cookie(settings.session_cookie_name, path="/")
+    response.delete_cookie(settings.csrf_cookie_name, path="/")
+
+
+@router.post("/register", response_model=UserOut, status_code=201)
+async def register(
+    body: RegisterRequest, response: Response, auth_service: AuthService = Depends(_get_auth_service)
+) -> UserOut:
+    user, session_id = await auth_service.register(body.email, body.password)
+    _set_auth_cookies(response, session_id)
+    return UserOut.from_user(user)
+
+
+@router.post("/login", response_model=UserOut)
+async def login(
+    body: LoginRequest,
+    request: Request,
+    response: Response,
+    auth_service: AuthService = Depends(_get_auth_service),
+) -> UserOut:
+    ip = request.client.host if request.client else "unknown"
+    user, session_id = await auth_service.login(body.email, body.password, ip)
+    _set_auth_cookies(response, session_id)
+    return UserOut.from_user(user)
+
+
+@router.post("/logout", status_code=204)
+async def logout(request: Request, response: Response, auth_service: AuthService = Depends(_get_auth_service)) -> None:
+    settings = get_settings()
+    session_id = request.cookies.get(settings.session_cookie_name)
+    if session_id:
+        require_csrf(request)
+        user_id = await auth_service.sessions.get_user_id(session_id)
+        if user_id:
+            await auth_service.logout(session_id, user_id)
+    _clear_auth_cookies(response)
+
+
+@router.post("/verify-email", response_model=MessageOut)
+async def verify_email(body: VerifyEmailRequest, auth_service: AuthService = Depends(_get_auth_service)) -> MessageOut:
+    await auth_service.verify_email(body.token)
+    return MessageOut(detail="Email verified")
+
+
+@router.post("/refresh", response_model=UserOut)
+async def refresh(
+    request: Request,
+    response: Response,
+    current_user: User = Depends(get_current_user),
+    auth_service: AuthService = Depends(_get_auth_service),
+    _csrf: None = Depends(require_csrf),
+) -> UserOut:
+    settings = get_settings()
+    old_session_id = request.cookies[settings.session_cookie_name]
+    new_session_id = await auth_service.refresh(current_user, old_session_id)
+    _set_auth_cookies(response, new_session_id)
+    return UserOut.from_user(current_user)
+
+
+@router.post("/forgot-password", response_model=MessageOut)
+async def forgot_password(
+    body: ForgotPasswordRequest, request: Request, auth_service: AuthService = Depends(_get_auth_service)
+) -> MessageOut:
+    ip = request.client.host if request.client else "unknown"
+    await auth_service.forgot_password(body.email, ip)
+    return MessageOut(detail="If that email is registered, a reset link has been sent")
+
+
+@router.post("/reset-password", response_model=MessageOut)
+async def reset_password(
+    body: ResetPasswordRequest, auth_service: AuthService = Depends(_get_auth_service)
+) -> MessageOut:
+    await auth_service.reset_password(body.token, body.new_password)
+    return MessageOut(detail="Password has been reset")
+
+
+@me_router.get("/me", response_model=UserOut)
+async def get_me(current_user: User = Depends(get_current_user)) -> UserOut:
+    return UserOut.from_user(current_user)

--- a/app/api/v1/router.py
+++ b/app/api/v1/router.py
@@ -1,8 +1,10 @@
 from fastapi import APIRouter
 
-from app.api.v1 import listings, search, vehicles
+from app.api.v1 import auth, listings, search, vehicles
 
 api_router = APIRouter(prefix="/api/v1")
+api_router.include_router(auth.router)
+api_router.include_router(auth.me_router)
 api_router.include_router(search.router)
 api_router.include_router(listings.router)
 api_router.include_router(vehicles.router)

--- a/app/auth/__init__.py
+++ b/app/auth/__init__.py
@@ -1,1 +1,8 @@
-"""Not started — session/token strategy is an open architecture question (cookie vs JWT)."""
+"""Session strategy: HttpOnly cookie + server-side session in Redis (not JWT).
+
+Chosen for a browser-first SPA client — see agent_documents/18_DECISIONS_AND_OPEN_QUESTIONS.md
+§Authentication. A cookie session avoids storing a bearer token somewhere JS can read it (XSS
+exposure), and gives trivial server-side revocation via Redis. The trade-off is CSRF: mutating
+cookie-authenticated endpoints require a double-submit `X-CSRF-Token` header (see
+app/auth/dependencies.py:require_csrf).
+"""

--- a/app/auth/dependencies.py
+++ b/app/auth/dependencies.py
@@ -1,0 +1,45 @@
+import secrets
+import uuid
+
+from fastapi import Depends, HTTPException, Request
+from redis.asyncio import Redis
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.repository import UserRepository
+from app.auth.sessions import SessionStore
+from app.config import get_settings
+from app.db.session import get_session
+from app.infrastructure.redis import get_redis
+from app.models.user import User
+
+
+async def get_current_user(
+    request: Request,
+    session: AsyncSession = Depends(get_session),
+    redis: Redis = Depends(get_redis),
+) -> User:
+    settings = get_settings()
+    session_id = request.cookies.get(settings.session_cookie_name)
+    if not session_id:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+
+    store = SessionStore(redis, ttl_seconds=settings.session_ttl_seconds)
+    user_id = await store.get_user_id(session_id)
+    if user_id is None:
+        raise HTTPException(status_code=401, detail="Session expired or invalid")
+
+    try:
+        user = await UserRepository(session).get_by_id(uuid.UUID(user_id))
+    except ValueError:
+        user = None
+    if user is None:
+        raise HTTPException(status_code=401, detail="Session expired or invalid")
+    return user
+
+
+def require_csrf(request: Request) -> None:
+    settings = get_settings()
+    cookie_value = request.cookies.get(settings.csrf_cookie_name)
+    header_value = request.headers.get(settings.csrf_header_name)
+    if not cookie_value or not header_value or not secrets.compare_digest(cookie_value, header_value):
+        raise HTTPException(status_code=403, detail="CSRF token missing or invalid")

--- a/app/auth/email.py
+++ b/app/auth/email.py
@@ -1,0 +1,59 @@
+import logging
+from functools import lru_cache
+from typing import Protocol
+
+import httpx
+
+from app.config import Settings, get_settings
+
+logger = logging.getLogger("app.auth.email")
+
+_RESEND_API_URL = "https://api.resend.com/emails"
+
+
+class EmailSender(Protocol):
+    async def send(self, to: str, subject: str, body: str) -> None: ...
+
+
+class LoggingEmailSender:
+    """Default sender while no real provider is configured — logs the email instead of sending
+    it, so register/verify-email/forgot-password/reset-password work end-to-end in local dev and
+    CI without any credentials. See app/config.py:resend_api_key.
+    """
+
+    async def send(self, to: str, subject: str, body: str) -> None:
+        logger.info("Email (not sent, no provider configured) to=%s subject=%r body=%r", to, subject, body)
+
+
+class ResendEmailSender:
+    """Sends via Resend (https://resend.com). A provider hiccup logs a warning rather than
+    raising, so a transient email-sending failure doesn't turn into a 500 on register/reset —
+    the user can always request a new verification/reset link.
+    """
+
+    def __init__(self, api_key: str, from_address: str):
+        self._api_key = api_key
+        self._from_address = from_address
+
+    async def send(self, to: str, subject: str, body: str) -> None:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            try:
+                response = await client.post(
+                    _RESEND_API_URL,
+                    headers={"Authorization": f"Bearer {self._api_key}"},
+                    json={"from": self._from_address, "to": [to], "subject": subject, "text": body},
+                )
+                response.raise_for_status()
+            except httpx.HTTPError:
+                logger.warning("Failed to send email to=%s subject=%r", to, subject, exc_info=True)
+
+
+def _build_email_sender(settings: Settings) -> EmailSender:
+    if settings.resend_api_key:
+        return ResendEmailSender(api_key=settings.resend_api_key, from_address=settings.email_from_address)
+    return LoggingEmailSender()
+
+
+@lru_cache
+def get_email_sender() -> EmailSender:
+    return _build_email_sender(get_settings())

--- a/app/auth/rate_limit.py
+++ b/app/auth/rate_limit.py
@@ -1,0 +1,19 @@
+from redis.asyncio import Redis
+
+
+class RateLimiter:
+    """Fixed-window counter. `hit` both records the attempt and reports whether it's still
+    within the limit — callers don't need a separate check-then-increment step.
+    """
+
+    def __init__(self, redis: Redis):
+        self._redis = redis
+
+    async def hit(self, key: str, limit: int, window_seconds: int) -> bool:
+        count = await self._redis.incr(key)
+        if count == 1:
+            await self._redis.expire(key, window_seconds)
+        return count <= limit
+
+    async def reset(self, key: str) -> None:
+        await self._redis.delete(key)

--- a/app/auth/repository.py
+++ b/app/auth/repository.py
@@ -1,0 +1,37 @@
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.user import User
+
+
+class UserRepository:
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def get_by_email(self, email: str) -> User | None:
+        stmt = select(User).where(User.email == email.lower())
+        return (await self.session.execute(stmt)).scalar_one_or_none()
+
+    async def get_by_id(self, user_id: uuid.UUID) -> User | None:
+        return await self.session.get(User, user_id)
+
+    async def create(self, email: str, password_hash: str) -> User:
+        user = User(email=email.lower(), password_hash=password_hash)
+        self.session.add(user)
+        await self.session.flush()
+        return user
+
+    async def mark_email_verified(self, user: User) -> None:
+        user.email_verified_at = datetime.now(timezone.utc)
+        await self.session.flush()
+
+    async def update_password_hash(self, user: User, password_hash: str) -> None:
+        user.password_hash = password_hash
+        await self.session.flush()
+
+    async def update_last_login(self, user: User) -> None:
+        user.last_login_at = datetime.now(timezone.utc)
+        await self.session.flush()

--- a/app/auth/schemas.py
+++ b/app/auth/schemas.py
@@ -1,0 +1,61 @@
+import uuid
+from datetime import datetime
+
+from disposable_email_domains import blocklist
+from pydantic import BaseModel, EmailStr, Field, field_validator
+
+from app.models.user import User
+
+
+def _reject_disposable_domain(email: EmailStr) -> EmailStr:
+    domain = email.rsplit("@", 1)[-1].lower()
+    if domain in blocklist:
+        raise ValueError("Disposable email addresses are not allowed")
+    return email
+
+
+class RegisterRequest(BaseModel):
+    email: EmailStr
+    password: str = Field(min_length=8, max_length=128)
+
+    _validate_domain = field_validator("email")(_reject_disposable_domain)
+
+
+class LoginRequest(BaseModel):
+    email: EmailStr
+    password: str = Field(max_length=128)
+
+
+class VerifyEmailRequest(BaseModel):
+    token: str
+
+
+class ForgotPasswordRequest(BaseModel):
+    email: EmailStr
+
+
+class ResetPasswordRequest(BaseModel):
+    token: str
+    new_password: str = Field(min_length=8, max_length=128)
+
+
+class UserOut(BaseModel):
+    id: uuid.UUID
+    email: str
+    email_verified: bool
+    created_at: datetime
+    last_login_at: datetime | None
+
+    @classmethod
+    def from_user(cls, user: User) -> "UserOut":
+        return cls(
+            id=user.id,
+            email=user.email,
+            email_verified=user.email_verified_at is not None,
+            created_at=user.created_at,
+            last_login_at=user.last_login_at,
+        )
+
+
+class MessageOut(BaseModel):
+    detail: str

--- a/app/auth/security.py
+++ b/app/auth/security.py
@@ -1,0 +1,15 @@
+from argon2 import PasswordHasher
+from argon2.exceptions import InvalidHash, VerificationError, VerifyMismatchError
+
+_hasher = PasswordHasher()
+
+
+def hash_password(password: str) -> str:
+    return _hasher.hash(password)
+
+
+def verify_password(password: str, password_hash: str) -> bool:
+    try:
+        return _hasher.verify(password_hash, password)
+    except (VerifyMismatchError, VerificationError, InvalidHash):
+        return False

--- a/app/auth/service.py
+++ b/app/auth/service.py
@@ -1,0 +1,115 @@
+import uuid
+
+from fastapi import HTTPException
+from redis.asyncio import Redis
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.email import EmailSender
+from app.auth.rate_limit import RateLimiter
+from app.auth.repository import UserRepository
+from app.auth.security import hash_password, verify_password
+from app.auth.sessions import SessionStore
+from app.auth.tokens import OneTimeTokenStore
+from app.config import get_settings
+from app.models.user import User
+
+
+class AuthService:
+    def __init__(self, session: AsyncSession, redis: Redis, email_sender: EmailSender):
+        self.session = session
+        self.email_sender = email_sender
+        self.settings = get_settings()
+        self.users = UserRepository(session)
+        self.rate_limiter = RateLimiter(redis)
+        self.sessions = SessionStore(redis, ttl_seconds=self.settings.session_ttl_seconds)
+        self.email_verify_tokens = OneTimeTokenStore(
+            redis, "email_verify", self.settings.email_verification_ttl_seconds
+        )
+        self.password_reset_tokens = OneTimeTokenStore(
+            redis, "password_reset", self.settings.password_reset_ttl_seconds
+        )
+
+    async def register(self, email: str, password: str) -> tuple[User, str]:
+        existing = await self.users.get_by_email(email)
+        if existing is not None:
+            raise HTTPException(status_code=409, detail="Email is already registered")
+
+        try:
+            user = await self.users.create(email, hash_password(password))
+        except IntegrityError:
+            await self.session.rollback()
+            raise HTTPException(status_code=409, detail="Email is already registered") from None
+        await self.session.commit()
+
+        token = await self.email_verify_tokens.issue(str(user.id))
+        verify_link = f"{self.settings.frontend_base_url}/verify-email?token={token}"
+        await self.email_sender.send(
+            to=user.email, subject="Verify your email", body=f"Confirm your email: {verify_link}"
+        )
+
+        session_id = await self.sessions.create(str(user.id))
+        return user, session_id
+
+    async def login(self, email: str, password: str, ip: str) -> tuple[User, str]:
+        rate_key = f"login_attempts:{ip}:{email.lower()}"
+        allowed = await self.rate_limiter.hit(
+            rate_key, self.settings.login_rate_limit_max_attempts, self.settings.login_rate_limit_window_seconds
+        )
+        if not allowed:
+            raise HTTPException(status_code=429, detail="Too many login attempts, try again later")
+
+        user = await self.users.get_by_email(email)
+        if user is None or not verify_password(password, user.password_hash):
+            raise HTTPException(status_code=401, detail="Invalid email or password")
+
+        await self.rate_limiter.reset(rate_key)
+        await self.users.update_last_login(user)
+        await self.session.commit()
+
+        session_id = await self.sessions.create(str(user.id))
+        return user, session_id
+
+    async def logout(self, session_id: str, user_id: str) -> None:
+        await self.sessions.delete(session_id, user_id)
+
+    async def verify_email(self, token: str) -> None:
+        user = await self._resolve_one_time_token(self.email_verify_tokens, token)
+        await self.users.mark_email_verified(user)
+        await self.session.commit()
+
+    async def refresh(self, user: User, old_session_id: str) -> str:
+        return await self.sessions.rotate(old_session_id, str(user.id))
+
+    async def forgot_password(self, email: str, ip: str) -> None:
+        rate_key = f"pwreset_attempts:{ip}:{email.lower()}"
+        allowed = await self.rate_limiter.hit(
+            rate_key,
+            self.settings.password_reset_rate_limit_max_attempts,
+            self.settings.password_reset_rate_limit_window_seconds,
+        )
+        if not allowed:
+            raise HTTPException(status_code=429, detail="Too many password reset requests, try again later")
+
+        # Always the same response whether or not the email exists — avoids account enumeration.
+        user = await self.users.get_by_email(email)
+        if user is not None:
+            token = await self.password_reset_tokens.issue(str(user.id))
+            reset_link = f"{self.settings.frontend_base_url}/reset-password?token={token}"
+            await self.email_sender.send(
+                to=user.email, subject="Reset your password", body=f"Reset your password: {reset_link}"
+            )
+
+    async def reset_password(self, token: str, new_password: str) -> None:
+        user = await self._resolve_one_time_token(self.password_reset_tokens, token)
+        await self.users.update_password_hash(user, hash_password(new_password))
+        await self.session.commit()
+        # A compromised password should not leave existing sessions alive.
+        await self.sessions.revoke_all_for_user(str(user.id))
+
+    async def _resolve_one_time_token(self, store: OneTimeTokenStore, token: str) -> User:
+        user_id = await store.consume(token)
+        user = await self.users.get_by_id(uuid.UUID(user_id)) if user_id else None
+        if user is None:
+            raise HTTPException(status_code=400, detail="Invalid or expired token")
+        return user

--- a/app/auth/sessions.py
+++ b/app/auth/sessions.py
@@ -1,0 +1,61 @@
+from typing import cast
+
+from redis.asyncio import Redis
+
+from app.auth.tokens import generate_token
+
+_SESSION_PREFIX = "session"
+_USER_SESSIONS_PREFIX = "user_sessions"
+
+
+class SessionStore:
+    """Server-side session state backing the `sid` cookie. See app/auth/__init__.py for why
+    this is a Redis-backed opaque session id rather than a JWT.
+
+    Also maintains a per-user set of active session ids (`user_sessions:{user_id}`) purely to
+    support `revoke_all_for_user` on password reset — individual sessions still expire on their
+    own TTL regardless of that set.
+    """
+
+    def __init__(self, redis: Redis, ttl_seconds: int):
+        self._redis = redis
+        self._ttl_seconds = ttl_seconds
+
+    def _session_key(self, session_id: str) -> str:
+        return f"{_SESSION_PREFIX}:{session_id}"
+
+    def _user_sessions_key(self, user_id: str) -> str:
+        return f"{_USER_SESSIONS_PREFIX}:{user_id}"
+
+    async def create(self, user_id: str) -> str:
+        session_id = generate_token()
+        user_sessions_key = self._user_sessions_key(user_id)
+        async with self._redis.pipeline(transaction=True) as pipe:
+            pipe.set(self._session_key(session_id), user_id, ex=self._ttl_seconds)
+            pipe.sadd(user_sessions_key, session_id)
+            pipe.expire(user_sessions_key, self._ttl_seconds)
+            await pipe.execute()
+        return session_id
+
+    async def get_user_id(self, session_id: str) -> str | None:
+        # get_redis() always sets decode_responses=True, so this is str at runtime; the redis-py
+        # stubs just don't encode that in Redis's type.
+        return cast("str | None", await self._redis.get(self._session_key(session_id)))
+
+    async def rotate(self, old_session_id: str, user_id: str) -> str:
+        new_session_id = await self.create(user_id)
+        await self.delete(old_session_id, user_id)
+        return new_session_id
+
+    async def delete(self, session_id: str, user_id: str) -> None:
+        async with self._redis.pipeline(transaction=True) as pipe:
+            pipe.delete(self._session_key(session_id))
+            pipe.srem(self._user_sessions_key(user_id), session_id)
+            await pipe.execute()
+
+    async def revoke_all_for_user(self, user_id: str) -> None:
+        user_sessions_key = self._user_sessions_key(user_id)
+        session_ids = await self._redis.smembers(user_sessions_key)
+        if session_ids:
+            await self._redis.delete(*(self._session_key(cast(str, sid)) for sid in session_ids))
+        await self._redis.delete(user_sessions_key)

--- a/app/auth/tokens.py
+++ b/app/auth/tokens.py
@@ -1,0 +1,44 @@
+import hashlib
+import secrets
+from typing import cast
+
+from redis.asyncio import Redis
+
+
+def generate_token() -> str:
+    return secrets.token_urlsafe(32)
+
+
+def _hash_token(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+class OneTimeTokenStore:
+    """Single-use, short-TTL tokens for email verification / password reset.
+
+    Only the token's hash is stored in Redis, so a Redis dump/KEYS scan doesn't leak a usable
+    token — the raw token exists only in the link sent to the user.
+    """
+
+    def __init__(self, redis: Redis, namespace: str, ttl_seconds: int):
+        self._redis = redis
+        self._namespace = namespace
+        self._ttl_seconds = ttl_seconds
+
+    def _key(self, token: str) -> str:
+        return f"{self._namespace}:{_hash_token(token)}"
+
+    async def issue(self, subject_id: str) -> str:
+        token = generate_token()
+        await self._redis.set(self._key(token), subject_id, ex=self._ttl_seconds)
+        return token
+
+    async def consume(self, token: str) -> str | None:
+        key = self._key(token)
+        subject_id = await self._redis.get(key)
+        if subject_id is None:
+            return None
+        await self._redis.delete(key)
+        # get_redis() always sets decode_responses=True, so this is str at runtime; the redis-py
+        # stubs just don't encode that in Redis's type.
+        return cast(str, subject_id)

--- a/app/config.py
+++ b/app/config.py
@@ -14,6 +14,25 @@ class Settings(BaseSettings):
         "http://localhost:3000",
     ]
 
+    # Auth: HttpOnly cookie + server-side Redis session (see app/auth/__init__.py).
+    session_cookie_name: str = "sid"
+    csrf_cookie_name: str = "csrf_token"
+    csrf_header_name: str = "X-CSRF-Token"
+    cookie_secure: bool = False
+    session_ttl_seconds: int = 60 * 60 * 24 * 14
+    email_verification_ttl_seconds: int = 60 * 60 * 24
+    password_reset_ttl_seconds: int = 60 * 30
+    login_rate_limit_max_attempts: int = 5
+    login_rate_limit_window_seconds: int = 60 * 15
+    password_reset_rate_limit_max_attempts: int = 3
+    password_reset_rate_limit_window_seconds: int = 60 * 60
+    frontend_base_url: str = "http://localhost:3000"
+
+    # Transactional email (verification/reset links). Unset -> falls back to a logging-only
+    # sender, so local dev/CI never need real credentials. See app/auth/email.py.
+    resend_api_key: str | None = None
+    email_from_address: str = "onboarding@resend.dev"
+
 
 @lru_cache
 def get_settings() -> Settings:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 -r requirements.txt
 ruff
 mypy
+fakeredis

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,7 @@ pytest-asyncio
 aiosqlite
 greenlet
 redis>=5.0
+argon2-cffi
+email-validator
+disposable-email-domains
+httpx

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import uuid
 from datetime import datetime, timezone
 
 import pytest_asyncio
+from fakeredis import FakeAsyncRedis
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
 from app.db.base import Base
@@ -20,6 +21,13 @@ async def session():
         yield s
 
     await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def redis():
+    client = FakeAsyncRedis(decode_responses=True)
+    yield client
+    await client.aclose()
 
 
 def make_listing(source_id: uuid.UUID, **overrides) -> Listing:

--- a/tests/unit/test_auth_endpoints.py
+++ b/tests/unit/test_auth_endpoints.py
@@ -1,0 +1,204 @@
+"""Endpoint-level tests driving the real FastAPI app over ASGI, not just the service layer —
+covers router wiring, actual Set-Cookie behavior, and CSRF enforcement that a pure service-layer
+test can't see.
+"""
+
+import pytest
+import pytest_asyncio
+from fakeredis import FakeAsyncRedis
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.auth.email import get_email_sender
+from app.config import get_settings
+from app.db.base import Base
+from app.db.session import get_session
+from app.infrastructure.redis import get_redis
+from app.main import app
+
+
+class RecordingEmailSender:
+    def __init__(self):
+        self.sent = []
+
+    async def send(self, to: str, subject: str, body: str) -> None:
+        self.sent.append({"to": to, "subject": subject, "body": body})
+
+    def last_token(self) -> str:
+        return self.sent[-1]["body"].rsplit("token=", 1)[-1]
+
+
+@pytest.fixture
+def email_sender():
+    return RecordingEmailSender()
+
+
+@pytest_asyncio.fixture
+async def client(email_sender):
+    # StaticPool + a shared connect_args keeps every get_session() call in this test on the same
+    # in-memory sqlite DB — without it, each dependency call would get its own throwaway DB and
+    # state wouldn't persist across the multiple HTTP calls in a flow (unlike tests/conftest.py's
+    # `session` fixture, which only ever opens one session per test).
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:", poolclass=StaticPool, connect_args={"check_same_thread": False}
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+
+    async def override_get_session():
+        async with session_factory() as session:
+            yield session
+
+    fake_redis = FakeAsyncRedis(decode_responses=True)
+
+    app.dependency_overrides[get_session] = override_get_session
+    app.dependency_overrides[get_redis] = lambda: fake_redis
+    app.dependency_overrides[get_email_sender] = lambda: email_sender
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as async_client:
+        yield async_client
+
+    app.dependency_overrides.clear()
+    await fake_redis.aclose()
+    await engine.dispose()
+
+
+def _csrf_headers(client: AsyncClient) -> dict[str, str]:
+    settings = get_settings()
+    return {settings.csrf_header_name: client.cookies[settings.csrf_cookie_name]}
+
+
+async def test_register_sets_cookies_with_expected_attributes(client):
+    response = await client.post("/api/v1/auth/register", json={"email": "new@example.com", "password": "hunter2pass"})
+    assert response.status_code == 201
+
+    set_cookie_headers = response.headers.get_list("set-cookie")
+    assert len(set_cookie_headers) == 2
+
+    sid_header = next(h for h in set_cookie_headers if h.startswith("sid="))
+    csrf_header = next(h for h in set_cookie_headers if h.startswith("csrf_token="))
+
+    assert "HttpOnly" in sid_header
+    assert "HttpOnly" not in csrf_header
+    for header in (sid_header, csrf_header):
+        assert "Path=/" in header
+        assert "SameSite=lax" in header
+
+
+async def test_full_flow_register_verify_login_me_refresh_logout(client, email_sender):
+    register_response = await client.post(
+        "/api/v1/auth/register", json={"email": "new@example.com", "password": "hunter2pass"}
+    )
+    assert register_response.status_code == 201
+    assert register_response.json()["email_verified"] is False
+
+    token = email_sender.last_token()
+    verify_response = await client.post("/api/v1/auth/verify-email", json={"token": token})
+    assert verify_response.status_code == 200
+
+    login_response = await client.post(
+        "/api/v1/auth/login", json={"email": "new@example.com", "password": "hunter2pass"}
+    )
+    assert login_response.status_code == 200
+    assert login_response.json()["email_verified"] is True
+
+    me_response = await client.get("/api/v1/me")
+    assert me_response.status_code == 200
+    assert me_response.json()["email"] == "new@example.com"
+
+    old_sid = client.cookies[get_settings().session_cookie_name]
+    refresh_response = await client.post("/api/v1/auth/refresh", headers=_csrf_headers(client))
+    assert refresh_response.status_code == 200
+    new_sid = client.cookies[get_settings().session_cookie_name]
+    assert new_sid != old_sid
+
+    logout_response = await client.post("/api/v1/auth/logout", headers=_csrf_headers(client))
+    assert logout_response.status_code == 204
+
+    me_after_logout = await client.get("/api/v1/me")
+    assert me_after_logout.status_code == 401
+
+
+async def test_refresh_without_csrf_header_is_rejected(client):
+    await client.post("/api/v1/auth/register", json={"email": "new@example.com", "password": "hunter2pass"})
+    response = await client.post("/api/v1/auth/refresh")
+    assert response.status_code == 403
+
+
+async def test_refresh_with_wrong_csrf_header_is_rejected(client):
+    await client.post("/api/v1/auth/register", json={"email": "new@example.com", "password": "hunter2pass"})
+    settings = get_settings()
+    response = await client.post("/api/v1/auth/refresh", headers={settings.csrf_header_name: "wrong-token"})
+    assert response.status_code == 403
+
+
+async def test_logout_without_session_cookie_is_a_no_op(client):
+    response = await client.post("/api/v1/auth/logout")
+    assert response.status_code == 204
+
+
+async def test_me_without_session_returns_401(client):
+    response = await client.get("/api/v1/me")
+    assert response.status_code == 401
+
+
+async def test_duplicate_register_returns_409(client):
+    await client.post("/api/v1/auth/register", json={"email": "new@example.com", "password": "hunter2pass"})
+    response = await client.post("/api/v1/auth/register", json={"email": "new@example.com", "password": "other-pass"})
+    assert response.status_code == 409
+
+
+async def test_disposable_email_domain_is_rejected(client):
+    response = await client.post(
+        "/api/v1/auth/register", json={"email": "new@mailinator.com", "password": "hunter2pass"}
+    )
+    assert response.status_code == 422
+
+
+async def test_login_is_rate_limited_after_too_many_attempts(client):
+    await client.post("/api/v1/auth/register", json={"email": "new@example.com", "password": "hunter2pass"})
+    limit = get_settings().login_rate_limit_max_attempts
+
+    for _ in range(limit):
+        response = await client.post(
+            "/api/v1/auth/login", json={"email": "new@example.com", "password": "wrong-password"}
+        )
+        assert response.status_code == 401
+
+    response = await client.post(
+        "/api/v1/auth/login", json={"email": "new@example.com", "password": "wrong-password"}
+    )
+    assert response.status_code == 429
+
+
+async def test_forgot_password_and_reset_flow(client, email_sender):
+    await client.post("/api/v1/auth/register", json={"email": "new@example.com", "password": "hunter2pass"})
+    email_sender.sent.clear()
+
+    forgot_response = await client.post("/api/v1/auth/forgot-password", json={"email": "new@example.com"})
+    assert forgot_response.status_code == 200
+
+    token = email_sender.last_token()
+    reset_response = await client.post(
+        "/api/v1/auth/reset-password", json={"token": token, "new_password": "brand-new-pass"}
+    )
+    assert reset_response.status_code == 200
+
+    old_password_login = await client.post(
+        "/api/v1/auth/login", json={"email": "new@example.com", "password": "hunter2pass"}
+    )
+    assert old_password_login.status_code == 401
+
+    new_password_login = await client.post(
+        "/api/v1/auth/login", json={"email": "new@example.com", "password": "brand-new-pass"}
+    )
+    assert new_password_login.status_code == 200
+
+
+async def test_forgot_password_for_unknown_email_still_returns_200(client, email_sender):
+    response = await client.post("/api/v1/auth/forgot-password", json={"email": "nobody@example.com"})
+    assert response.status_code == 200
+    assert email_sender.sent == []

--- a/tests/unit/test_auth_rate_limit.py
+++ b/tests/unit/test_auth_rate_limit.py
@@ -1,0 +1,33 @@
+from app.auth.rate_limit import RateLimiter
+
+
+async def test_allowed_up_to_limit(redis):
+    limiter = RateLimiter(redis)
+    key = "test:limit"
+    for _ in range(3):
+        assert await limiter.hit(key, limit=3, window_seconds=60) is True
+
+
+async def test_blocked_after_limit_exceeded(redis):
+    limiter = RateLimiter(redis)
+    key = "test:limit"
+    for _ in range(3):
+        await limiter.hit(key, limit=3, window_seconds=60)
+    assert await limiter.hit(key, limit=3, window_seconds=60) is False
+
+
+async def test_reset_clears_the_counter(redis):
+    limiter = RateLimiter(redis)
+    key = "test:limit"
+    for _ in range(3):
+        await limiter.hit(key, limit=3, window_seconds=60)
+    await limiter.reset(key)
+    assert await limiter.hit(key, limit=3, window_seconds=60) is True
+
+
+async def test_ttl_set_on_first_hit(redis):
+    limiter = RateLimiter(redis)
+    key = "test:limit"
+    await limiter.hit(key, limit=5, window_seconds=60)
+    ttl = await redis.ttl(key)
+    assert 0 < ttl <= 60

--- a/tests/unit/test_auth_repository.py
+++ b/tests/unit/test_auth_repository.py
@@ -1,0 +1,57 @@
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from app.auth.repository import UserRepository
+
+
+async def test_create_and_get_by_email(session):
+    repo = UserRepository(session)
+    user = await repo.create("Person@Example.com", "hashed")
+    assert user.email == "person@example.com"
+
+    fetched = await repo.get_by_email("Person@Example.com")
+    assert fetched is not None
+    assert fetched.id == user.id
+
+
+async def test_get_by_id(session):
+    repo = UserRepository(session)
+    user = await repo.create("person@example.com", "hashed")
+    fetched = await repo.get_by_id(user.id)
+    assert fetched is not None
+    assert fetched.email == "person@example.com"
+
+
+async def test_get_by_email_unknown_returns_none(session):
+    repo = UserRepository(session)
+    assert await repo.get_by_email("nobody@example.com") is None
+
+
+async def test_duplicate_email_raises_integrity_error(session):
+    repo = UserRepository(session)
+    await repo.create("person@example.com", "hashed")
+    with pytest.raises(IntegrityError):
+        await repo.create("person@example.com", "other-hash")
+
+
+async def test_mark_email_verified(session):
+    repo = UserRepository(session)
+    user = await repo.create("person@example.com", "hashed")
+    assert user.email_verified_at is None
+    await repo.mark_email_verified(user)
+    assert user.email_verified_at is not None
+
+
+async def test_update_password_hash(session):
+    repo = UserRepository(session)
+    user = await repo.create("person@example.com", "old-hash")
+    await repo.update_password_hash(user, "new-hash")
+    assert user.password_hash == "new-hash"
+
+
+async def test_update_last_login(session):
+    repo = UserRepository(session)
+    user = await repo.create("person@example.com", "hashed")
+    assert user.last_login_at is None
+    await repo.update_last_login(user)
+    assert user.last_login_at is not None

--- a/tests/unit/test_auth_security.py
+++ b/tests/unit/test_auth_security.py
@@ -1,0 +1,19 @@
+from app.auth.security import hash_password, verify_password
+
+
+def test_hash_is_salted():
+    assert hash_password("hunter2pass") != hash_password("hunter2pass")
+
+
+def test_verify_password_roundtrip():
+    hashed = hash_password("correct horse battery staple")
+    assert verify_password("correct horse battery staple", hashed) is True
+
+
+def test_verify_password_rejects_wrong_password():
+    hashed = hash_password("correct horse battery staple")
+    assert verify_password("wrong password", hashed) is False
+
+
+def test_verify_password_rejects_garbage_hash():
+    assert verify_password("anything", "not-a-real-hash") is False

--- a/tests/unit/test_auth_service.py
+++ b/tests/unit/test_auth_service.py
@@ -1,0 +1,182 @@
+import pytest
+from fastapi import HTTPException
+
+from app.auth.repository import UserRepository
+from app.auth.security import verify_password
+from app.auth.service import AuthService
+
+
+class RecordingEmailSender:
+    def __init__(self):
+        self.sent = []
+
+    async def send(self, to: str, subject: str, body: str) -> None:
+        self.sent.append({"to": to, "subject": subject, "body": body})
+
+    def last_token(self) -> str:
+        return self.sent[-1]["body"].rsplit("token=", 1)[-1]
+
+
+@pytest.fixture
+def email_sender():
+    return RecordingEmailSender()
+
+
+@pytest.fixture
+def auth_service(session, redis, email_sender):
+    return AuthService(session, redis, email_sender)
+
+
+async def test_register_creates_user_with_hashed_password(auth_service, session):
+    user, session_id = await auth_service.register("new@example.com", "correct horse battery")
+    assert user.password_hash != "correct horse battery"
+    assert verify_password("correct horse battery", user.password_hash)
+    assert session_id
+
+    fetched = await UserRepository(session).get_by_email("new@example.com")
+    assert fetched is not None
+
+
+async def test_register_sends_verification_email(auth_service, email_sender):
+    await auth_service.register("new@example.com", "correct horse battery")
+    assert len(email_sender.sent) == 1
+    assert email_sender.sent[0]["to"] == "new@example.com"
+
+
+async def test_register_creates_a_working_session(auth_service):
+    _, session_id = await auth_service.register("new@example.com", "correct horse battery")
+    assert await auth_service.sessions.get_user_id(session_id) is not None
+
+
+async def test_register_duplicate_email_raises_409(auth_service):
+    await auth_service.register("new@example.com", "correct horse battery")
+    with pytest.raises(HTTPException) as exc_info:
+        await auth_service.register("new@example.com", "another password")
+    assert exc_info.value.status_code == 409
+
+
+async def test_login_success(auth_service):
+    await auth_service.register("new@example.com", "correct horse battery")
+    user, session_id = await auth_service.login("new@example.com", "correct horse battery", ip="127.0.0.1")
+    assert user.email == "new@example.com"
+    assert await auth_service.sessions.get_user_id(session_id) is not None
+
+
+async def test_login_wrong_password(auth_service):
+    await auth_service.register("new@example.com", "correct horse battery")
+    with pytest.raises(HTTPException) as exc_info:
+        await auth_service.login("new@example.com", "wrong password", ip="127.0.0.1")
+    assert exc_info.value.status_code == 401
+
+
+async def test_login_unknown_email(auth_service):
+    with pytest.raises(HTTPException) as exc_info:
+        await auth_service.login("nobody@example.com", "whatever", ip="127.0.0.1")
+    assert exc_info.value.status_code == 401
+
+
+async def test_login_rate_limited_after_max_attempts(auth_service):
+    await auth_service.register("new@example.com", "correct horse battery")
+    for _ in range(auth_service.settings.login_rate_limit_max_attempts):
+        with pytest.raises(HTTPException) as exc_info:
+            await auth_service.login("new@example.com", "wrong password", ip="127.0.0.1")
+        assert exc_info.value.status_code == 401
+
+    with pytest.raises(HTTPException) as exc_info:
+        await auth_service.login("new@example.com", "wrong password", ip="127.0.0.1")
+    assert exc_info.value.status_code == 429
+
+
+async def test_login_success_clears_rate_limit_counter(auth_service):
+    await auth_service.register("new@example.com", "correct horse battery")
+    with pytest.raises(HTTPException):
+        await auth_service.login("new@example.com", "wrong password", ip="127.0.0.1")
+
+    await auth_service.login("new@example.com", "correct horse battery", ip="127.0.0.1")
+
+    key = "login_attempts:127.0.0.1:new@example.com"
+    assert await auth_service.rate_limiter.hit(key, limit=1, window_seconds=60) is True
+
+
+async def test_logout_deletes_session(auth_service):
+    user, session_id = await auth_service.register("new@example.com", "correct horse battery")
+    await auth_service.logout(session_id, str(user.id))
+    assert await auth_service.sessions.get_user_id(session_id) is None
+
+
+async def test_verify_email_with_valid_token(auth_service, email_sender):
+    await auth_service.register("new@example.com", "correct horse battery")
+    token = email_sender.last_token()
+    await auth_service.verify_email(token)
+
+    fetched = await UserRepository(auth_service.session).get_by_email("new@example.com")
+    assert fetched.email_verified_at is not None
+
+
+async def test_verify_email_token_is_single_use(auth_service, email_sender):
+    await auth_service.register("new@example.com", "correct horse battery")
+    token = email_sender.last_token()
+    await auth_service.verify_email(token)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await auth_service.verify_email(token)
+    assert exc_info.value.status_code == 400
+
+
+async def test_verify_email_invalid_token(auth_service):
+    with pytest.raises(HTTPException) as exc_info:
+        await auth_service.verify_email("not-a-real-token")
+    assert exc_info.value.status_code == 400
+
+
+async def test_refresh_rotates_session(auth_service):
+    user, old_session_id = await auth_service.register("new@example.com", "correct horse battery")
+    new_session_id = await auth_service.refresh(user, old_session_id)
+    assert new_session_id != old_session_id
+    assert await auth_service.sessions.get_user_id(old_session_id) is None
+    assert await auth_service.sessions.get_user_id(new_session_id) == str(user.id)
+
+
+async def test_forgot_password_sends_email_for_existing_user(auth_service, email_sender):
+    await auth_service.register("new@example.com", "correct horse battery")
+    email_sender.sent.clear()
+
+    await auth_service.forgot_password("new@example.com", ip="127.0.0.1")
+    assert len(email_sender.sent) == 1
+
+
+async def test_forgot_password_is_generic_for_unknown_email(auth_service, email_sender):
+    # Must not raise and must not reveal whether the account exists.
+    await auth_service.forgot_password("nobody@example.com", ip="127.0.0.1")
+    assert email_sender.sent == []
+
+
+async def test_forgot_password_rate_limited(auth_service):
+    await auth_service.register("new@example.com", "correct horse battery")
+    limit = auth_service.settings.password_reset_rate_limit_max_attempts
+    for _ in range(limit):
+        await auth_service.forgot_password("new@example.com", ip="127.0.0.1")
+
+    with pytest.raises(HTTPException) as exc_info:
+        await auth_service.forgot_password("new@example.com", ip="127.0.0.1")
+    assert exc_info.value.status_code == 429
+
+
+async def test_reset_password_with_valid_token(auth_service, email_sender):
+    user, old_session_id = await auth_service.register("new@example.com", "correct horse battery")
+    await auth_service.forgot_password("new@example.com", ip="127.0.0.1")
+    token = email_sender.last_token()
+
+    await auth_service.reset_password(token, "brand new password")
+
+    fetched = await UserRepository(auth_service.session).get_by_id(user.id)
+    assert verify_password("brand new password", fetched.password_hash)
+    assert not verify_password("correct horse battery", fetched.password_hash)
+    # Password reset must kill sessions issued before it.
+    assert await auth_service.sessions.get_user_id(old_session_id) is None
+
+
+async def test_reset_password_invalid_token(auth_service):
+    with pytest.raises(HTTPException) as exc_info:
+        await auth_service.reset_password("not-a-real-token", "brand new password")
+    assert exc_info.value.status_code == 400

--- a/tests/unit/test_auth_sessions.py
+++ b/tests/unit/test_auth_sessions.py
@@ -1,0 +1,53 @@
+from app.auth.sessions import SessionStore
+
+
+async def test_create_and_get_user_id(redis):
+    store = SessionStore(redis, ttl_seconds=60)
+    session_id = await store.create("user-1")
+    assert await store.get_user_id(session_id) == "user-1"
+
+
+async def test_get_user_id_unknown_session_returns_none(redis):
+    store = SessionStore(redis, ttl_seconds=60)
+    assert await store.get_user_id("never-created") is None
+
+
+async def test_delete_removes_session(redis):
+    store = SessionStore(redis, ttl_seconds=60)
+    session_id = await store.create("user-1")
+    await store.delete(session_id, "user-1")
+    assert await store.get_user_id(session_id) is None
+
+
+async def test_rotate_issues_new_id_and_invalidates_old(redis):
+    store = SessionStore(redis, ttl_seconds=60)
+    old_id = await store.create("user-1")
+    new_id = await store.rotate(old_id, "user-1")
+    assert new_id != old_id
+    assert await store.get_user_id(old_id) is None
+    assert await store.get_user_id(new_id) == "user-1"
+
+
+async def test_revoke_all_for_user_removes_every_session(redis):
+    store = SessionStore(redis, ttl_seconds=60)
+    id_a = await store.create("user-1")
+    id_b = await store.create("user-1")
+    await store.revoke_all_for_user("user-1")
+    assert await store.get_user_id(id_a) is None
+    assert await store.get_user_id(id_b) is None
+
+
+async def test_revoke_all_for_user_does_not_affect_other_users(redis):
+    store = SessionStore(redis, ttl_seconds=60)
+    victim_session = await store.create("user-1")
+    other_session = await store.create("user-2")
+    await store.revoke_all_for_user("user-1")
+    assert await store.get_user_id(victim_session) is None
+    assert await store.get_user_id(other_session) == "user-2"
+
+
+async def test_user_sessions_set_ttl_is_armed(redis):
+    store = SessionStore(redis, ttl_seconds=60)
+    await store.create("user-1")
+    ttl = await redis.ttl("user_sessions:user-1")
+    assert 0 < ttl <= 60

--- a/tests/unit/test_auth_tokens.py
+++ b/tests/unit/test_auth_tokens.py
@@ -1,0 +1,33 @@
+import hashlib
+
+from app.auth.tokens import OneTimeTokenStore, generate_token
+
+
+def test_generate_token_is_unique():
+    assert generate_token() != generate_token()
+
+
+async def test_issue_then_consume_roundtrip(redis):
+    store = OneTimeTokenStore(redis, "test_ns", ttl_seconds=60)
+    token = await store.issue("user-123")
+    assert await store.consume(token) == "user-123"
+
+
+async def test_consume_is_single_use(redis):
+    store = OneTimeTokenStore(redis, "test_ns", ttl_seconds=60)
+    token = await store.issue("user-123")
+    await store.consume(token)
+    assert await store.consume(token) is None
+
+
+async def test_consume_unknown_token_returns_none(redis):
+    store = OneTimeTokenStore(redis, "test_ns", ttl_seconds=60)
+    assert await store.consume("never-issued") is None
+
+
+async def test_issued_token_has_ttl(redis):
+    store = OneTimeTokenStore(redis, "test_ns", ttl_seconds=60)
+    token = await store.issue("user-123")
+    key = f"test_ns:{hashlib.sha256(token.encode()).hexdigest()}"
+    ttl = await redis.ttl(key)
+    assert 0 < ttl <= 60


### PR DESCRIPTION
## Summary

Closes #7. Implements register/login/logout/verify-email/refresh/forgot-password/reset-password/`GET /me` per `agent_documents/08_API.md` and `11_SECURITY.md`.

**Session strategy (the acceptance criterion this issue explicitly called out): secure HttpOnly cookie + server-side session in Redis, not JWT.** Documented in `app/auth/__init__.py`. Chosen for this browser-first SPA client — avoids storing a bearer token somewhere JS can read it, and gives trivial server-side revocation via Redis, at the cost of needing CSRF protection (added below).

- Argon2id password hashing (`app/auth/security.py`)
- Redis session store with rotation-on-`/auth/refresh` and revoke-all-on-password-reset (`app/auth/sessions.py`)
- Double-submit `X-CSRF-Token` cookie/header for cookie-authenticated mutations (`refresh`, `logout`)
- Redis-backed rate limiting on login (5/15min) and forgot-password (3/hour), keyed by IP+email
- One-time, short-TTL tokens for email verification (24h) and password reset (30min), stored as a SHA-256 hash so a Redis dump doesn't leak a usable token
- Disposable-email-domain blocklist on `/auth/register` (anti temp-mail abuse)
- Email sending behind an `EmailSender` interface (`app/auth/email.py`): `ResendEmailSender` for production, `LoggingEmailSender` fallback when `RESEND_API_KEY` is unset — so local dev/CI need no real credentials

**Deployment note (not part of this diff):** production sending requires `RESEND_API_KEY` and a domain verified with Resend (DKIM/SPF/DMARC DNS records) set via `EMAIL_FROM_ADDRESS`. Already set up and verified against real Resend delivery during development of this PR; without it the app transparently falls back to logging emails instead of sending them, so nothing here is blocked on that.

Explicitly out of scope: RBAC/roles, JWT, self-hosted SMTP.

## Test plan

- [x] `ruff check .` clean
- [x] `mypy app` clean
- [x] `pytest` — 66 passed, including a full-stack endpoint test (`tests/unit/test_auth_endpoints.py`) driving the real app over ASGI and asserting actual `Set-Cookie` headers, CSRF enforcement, and rate limiting
- [x] Manual smoke test against real Postgres + Redis (docker-compose) and real Resend delivery: register → verify-email → login → `/me` → refresh (cookie rotates) → logout → `/me` returns 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)