### PR TITLE
Allow Vite dev origin in CORS, cap search pagination

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -12,6 +12,7 @@ class Settings(BaseSettings):
         "http://localhost:63342",
         "http://0.0.0.0:8000",
         "http://localhost:3000",
+        "http://localhost:5173",
     ]
 
     # Auth: HttpOnly cookie + server-side Redis session (see app/auth/__init__.py).

--- a/app/search/query.py
+++ b/app/search/query.py
@@ -42,7 +42,7 @@ class SearchRequest(BaseModel):
     group_by: list[str] | None = Field(
         default_factory=lambda: ["make", "model", "engine_volume_cc", "fuel_type", "transmission"]
     )
-    min_group_count: int | None = None
+    min_group_count: int | None = Field(default=None, ge=0)
     sort: str = "count_desc"
-    page: int = 1
-    page_size: int = 20
+    page: int = Field(default=1, ge=1)
+    page_size: int = Field(default=20, ge=1, le=100)

--- a/tests/unit/test_search_request_limits.py
+++ b/tests/unit/test_search_request_limits.py
@@ -1,0 +1,24 @@
+import pytest
+from pydantic import ValidationError
+
+from app.search.query import SearchRequest
+
+
+@pytest.mark.parametrize("page_size", [0, 101])
+def test_page_size_out_of_range_rejected(page_size):
+    with pytest.raises(ValidationError):
+        SearchRequest(page_size=page_size)
+
+
+def test_page_below_one_rejected():
+    with pytest.raises(ValidationError):
+        SearchRequest(page=0)
+
+
+def test_negative_min_group_count_rejected():
+    with pytest.raises(ValidationError):
+        SearchRequest(min_group_count=-1)
+
+
+def test_page_size_within_range_accepted():
+    assert SearchRequest(page_size=100).page_size == 100


### PR DESCRIPTION
## Summary
- `app/config.py`: add `http://localhost:5173` (Vite dev server default) to `cors_origins` — the upcoming frontend (React+Vite per `docs/adr/03_FRONTEND.md`) would otherwise be blocked by the browser on its first request
- `app/search/query.py`: `SearchRequest.page_size` capped to 1-100, `page` to >=1, `min_group_count` to >=0 — previously unbounded `int`s that a real browser client could send arbitrarily large values for

Part of #55's "pagination limits" acceptance criterion; scoped narrowly to what's needed before frontend work starts (not the full RBAC/SSRF/rate-limit surface of that issue).

Verified locally: `ruff check .` / `mypy app` / `pytest` (72/72) clean; live `docker compose up postgres redis api` + CORS preflight from `http://localhost:5173` returns `access-control-allow-origin`, `page_size=101`/`page=0` return 422, `page_size=100` returns 200.

## Test plan
- [x] `pytest` (72/72)
- [x] `ruff check .` / `mypy app`
- [x] Live CORS preflight + pagination bounds against docker-compose stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)