### PR TITLE
Fix stale index.html caching after frontend deploys

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -4,6 +4,17 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Vite's hashed asset filenames change on every build, so they're safe to cache forever —
+    # the HTML that references them must never be cached, or a deploy can leave clients (and any
+    # proxy in front, e.g. Cloudflare) serving an old index.html that points at deleted assets.
+    location = /index.html {
+        add_header Cache-Control "no-cache";
+    }
+
+    location /assets/ {
+        add_header Cache-Control "public, max-age=31536000, immutable";
+    }
+
     location / {
         try_files $uri $uri/ /index.html;
     }


### PR DESCRIPTION
## Summary
`nginx.conf` set no `Cache-Control` for `index.html`, only for the SPA fallback routing. Vite's hashed asset filenames change every build, but the HTML referencing them could still be served stale by a browser or an intermediary proxy (Cloudflare, in front of `carradar.rs`) — which is exactly what happened right after merging #65: the site kept serving the pre-merge JS bundle (old hash) until a cache-busting reload forced a fresh fetch.

Now `index.html` gets `Cache-Control: no-cache` (always revalidated) and `/assets/*` gets `public, max-age=31536000, immutable` (safe — filenames are content-hashed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)