### PR TITLE
Fix Railway marking info logs as errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
-CMD ["/bin/sh", "-c", "alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port 8000"]
+CMD ["/bin/sh", "-c", "alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port 8000 --log-config uvicorn_log_config.json"]

--- a/alembic.ini
+++ b/alembic.ini
@@ -140,7 +140,7 @@ qualname = alembic
 
 [handler_console]
 class = StreamHandler
-args = (sys.stderr,)
+args = (sys.stdout,)
 level = NOTSET
 formatter = generic
 

--- a/scraping/utilities.py
+++ b/scraping/utilities.py
@@ -1,6 +1,7 @@
 import logging
 import random
 import re
+import sys
 from urllib.parse import urlparse
 
 import brotli
@@ -8,9 +9,10 @@ from bs4 import Tag, BeautifulSoup
 
 logger = logging.getLogger("scraper")
 logger.setLevel(logging.INFO)
+logger.propagate = False
 
 if not logger.hasHandlers():
-    handler = logging.StreamHandler()
+    handler = logging.StreamHandler(sys.stdout)
     handler.setFormatter(logging.Formatter(fmt='%(asctime)s %(levelname)s %(message)s', datefmt='%Y-%m-%d %H:%M:%S'))
     handler.setLevel(logging.INFO)
     logger.addHandler(handler)

--- a/uvicorn_log_config.json
+++ b/uvicorn_log_config.json
@@ -1,0 +1,36 @@
+{
+  "version": 1,
+  "disable_existing_loggers": false,
+  "formatters": {
+    "default": {
+      "()": "uvicorn.logging.DefaultFormatter",
+      "fmt": "%(levelprefix)s %(message)s",
+      "use_colors": null
+    },
+    "access": {
+      "()": "uvicorn.logging.AccessFormatter",
+      "fmt": "%(levelprefix)s %(client_addr)s - \"%(request_line)s\" %(status_code)s"
+    }
+  },
+  "handlers": {
+    "default": {
+      "formatter": "default",
+      "class": "logging.StreamHandler",
+      "stream": "ext://sys.stdout"
+    },
+    "access": {
+      "formatter": "access",
+      "class": "logging.StreamHandler",
+      "stream": "ext://sys.stdout"
+    }
+  },
+  "loggers": {
+    "uvicorn": {"handlers": ["default"], "level": "INFO", "propagate": false},
+    "uvicorn.error": {"level": "INFO"},
+    "uvicorn.access": {"handlers": ["access"], "level": "INFO", "propagate": false}
+  },
+  "root": {
+    "handlers": ["default"],
+    "level": "INFO"
+  }
+}


### PR DESCRIPTION
## Summary
- Alembic's console handler, uvicorn's default logging config, and the scraper logger all wrote to stderr, and Railway classifies log severity by stream (stderr → error) rather than by actual log level — so ordinary INFO logs (migrations, startup, scraping) showed up as errors in the Railway UI.
- Routed those loggers to stdout: `alembic.ini` console handler, a new `uvicorn_log_config.json` passed via `--log-config` in the Dockerfile CMD, and `scraping/utilities.py`'s handler.

## Test plan
- [x] Verified the uvicorn log config locally (separate venv): startup/access logs land on stdout, stderr is empty.
- [ ] Confirm on the next Railway deploy that migration/startup/scraper logs show as "info" instead of "error".

🤖 Generated with [Claude Code](https://claude.com/claude-code)