### PR TITLE
Add admin role, CLI promote/demote, and scrape-job management API+UI

### DIFF
--- a/app/api/v1/scrape.py
+++ b/app/api/v1/scrape.py
@@ -3,10 +3,11 @@ from collections.abc import Awaitable, Callable
 from datetime import datetime, timezone
 
 from arq.jobs import Job
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.auth.dependencies import get_current_user, require_csrf
+from app.auth.dependencies import require_admin, require_csrf
 from app.db.session import get_session
 from app.models.scrape_job import ScrapeJob, ScrapeJobStatus, ScrapeJobType
 from app.models.user import User
@@ -15,6 +16,8 @@ from app.scraping.queue import get_arq_pool, get_job_enqueuer
 from app.scraping.schemas import ScrapeJobCreate, ScrapeJobOut, encode_job_query
 from app.sources.registry import SOURCE_REGISTRY
 
+# Job management is an admin action (docs/adr/13_ADMIN.md "Controls"), not a regular-user
+# feature — every route here sits behind require_admin rather than get_current_user.
 router = APIRouter(prefix="/scrape", tags=["scrape"])
 
 _TERMINAL_STATUSES = {
@@ -23,6 +26,25 @@ _TERMINAL_STATUSES = {
     ScrapeJobStatus.FAILED,
     ScrapeJobStatus.CANCELLED,
 }
+_RETRYABLE_STATUSES = {ScrapeJobStatus.FAILED, ScrapeJobStatus.CANCELLED}
+
+
+@router.get("/jobs", response_model=list[ScrapeJobOut])
+async def list_scrape_jobs(
+    session: AsyncSession = Depends(get_session),
+    _current_user: User = Depends(require_admin),
+    status: ScrapeJobStatus | None = None,
+    source_id: uuid.UUID | None = None,
+    limit: int = Query(default=50, ge=1, le=200),
+    offset: int = Query(default=0, ge=0),
+) -> list[ScrapeJobOut]:
+    stmt = select(ScrapeJob).order_by(ScrapeJob.created_at.desc()).limit(limit).offset(offset)
+    if status is not None:
+        stmt = stmt.where(ScrapeJob.status == status)
+    if source_id is not None:
+        stmt = stmt.where(ScrapeJob.source_id == source_id)
+    jobs = (await session.execute(stmt)).scalars().all()
+    return [ScrapeJobOut.model_validate(job) for job in jobs]
 
 
 @router.post("/jobs", response_model=ScrapeJobOut, status_code=201)
@@ -30,7 +52,7 @@ async def create_scrape_job(
     payload: ScrapeJobCreate,
     session: AsyncSession = Depends(get_session),
     enqueue: Callable[[str], Awaitable[None]] = Depends(get_job_enqueuer),
-    _current_user: User = Depends(get_current_user),
+    _current_user: User = Depends(require_admin),
     _csrf: None = Depends(require_csrf),
 ) -> ScrapeJobOut:
     adapter_cls = SOURCE_REGISTRY.get(payload.source_code)
@@ -61,7 +83,7 @@ async def create_scrape_job(
 async def get_scrape_job(
     job_id: uuid.UUID,
     session: AsyncSession = Depends(get_session),
-    _current_user: User = Depends(get_current_user),
+    _current_user: User = Depends(require_admin),
 ) -> ScrapeJobOut:
     job = await session.get(ScrapeJob, job_id)
     if job is None:
@@ -73,7 +95,7 @@ async def get_scrape_job(
 async def cancel_scrape_job(
     job_id: uuid.UUID,
     session: AsyncSession = Depends(get_session),
-    _current_user: User = Depends(get_current_user),
+    _current_user: User = Depends(require_admin),
     _csrf: None = Depends(require_csrf),
 ) -> ScrapeJobOut:
     """Best-effort: flips the DB row to CANCELLED and tries to abort the queued arq job. The
@@ -98,4 +120,31 @@ async def cancel_scrape_job(
         except Exception:  # noqa: BLE001 - cancellation is best-effort, DB state already updated
             pass
 
+    return ScrapeJobOut.model_validate(job)
+
+
+@router.post("/jobs/{job_id}/retry", response_model=ScrapeJobOut)
+async def retry_scrape_job(
+    job_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    enqueue: Callable[[str], Awaitable[None]] = Depends(get_job_enqueuer),
+    _current_user: User = Depends(require_admin),
+    _csrf: None = Depends(require_csrf),
+) -> ScrapeJobOut:
+    """Re-enqueues a FAILED/CANCELLED job in place (same row, same query) rather than creating a
+    new one, so its history stays under one job id.
+    """
+    job = await session.get(ScrapeJob, job_id)
+    if job is None:
+        raise HTTPException(status_code=404, detail="Scrape job not found")
+    if job.status not in _RETRYABLE_STATUSES:
+        raise HTTPException(status_code=400, detail=f"Cannot retry a job in status {job.status.value!r}")
+
+    job.status = ScrapeJobStatus.PENDING
+    job.started_at = None
+    job.finished_at = None
+    job.error = None
+    await session.commit()
+
+    await enqueue(str(job.id))
     return ScrapeJobOut.model_validate(job)

--- a/app/auth/cli.py
+++ b/app/auth/cli.py
@@ -1,0 +1,47 @@
+"""Grant or revoke admin access for an existing user, by email.
+
+Deliberately promotes/demotes an already-registered account rather than taking a password itself:
+the account still goes through the normal register + argon2-hash + email-verification flow, so
+this command never handles a plaintext credential and there is no standing admin password in an
+env var. See docs/adr/20_ROLES_AND_ADMIN.md. Run on a host with DB access (docker exec / railway run):
+
+    python -m app.auth.cli promote --email admin@example.com
+    python -m app.auth.cli demote --email admin@example.com
+"""
+
+import argparse
+import asyncio
+
+from app.auth.repository import UserRepository
+from app.db.session import get_session
+from app.models.user import UserRole
+
+
+async def _set_role(email: str, role: UserRole) -> None:
+    async for session in get_session():
+        repo = UserRepository(session)
+        user = await repo.get_by_email(email)
+        if user is None:
+            raise SystemExit(f"No user with email {email!r}")
+        await repo.set_role(user, role)
+        await session.commit()
+        print(f"{user.email} is now {role.value}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    promote = subparsers.add_parser("promote", help="Grant admin access to an existing user")
+    promote.add_argument("--email", required=True)
+
+    demote = subparsers.add_parser("demote", help="Revoke admin access from an existing user")
+    demote.add_argument("--email", required=True)
+
+    args = parser.parse_args()
+    role = UserRole.ADMIN if args.command == "promote" else UserRole.USER
+    asyncio.run(_set_role(args.email, role))
+
+
+if __name__ == "__main__":
+    main()

--- a/app/auth/dependencies.py
+++ b/app/auth/dependencies.py
@@ -10,7 +10,7 @@ from app.auth.sessions import SessionStore
 from app.config import get_settings
 from app.db.session import get_session
 from app.infrastructure.redis import get_redis
-from app.models.user import User
+from app.models.user import User, UserRole
 
 
 async def get_current_user(
@@ -35,6 +35,12 @@ async def get_current_user(
     if user is None:
         raise HTTPException(status_code=401, detail="Session expired or invalid")
     return user
+
+
+async def require_admin(current_user: User = Depends(get_current_user)) -> User:
+    if current_user.role != UserRole.ADMIN:
+        raise HTTPException(status_code=403, detail="Admin access required")
+    return current_user
 
 
 def require_csrf(request: Request) -> None:

--- a/app/auth/repository.py
+++ b/app/auth/repository.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.user import User
+from app.models.user import User, UserRole
 
 
 class UserRepository:
@@ -34,4 +34,8 @@ class UserRepository:
 
     async def update_last_login(self, user: User) -> None:
         user.last_login_at = datetime.now(timezone.utc)
+        await self.session.flush()
+
+    async def set_role(self, user: User, role: UserRole) -> None:
+        user.role = role
         await self.session.flush()

--- a/app/auth/schemas.py
+++ b/app/auth/schemas.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from disposable_email_domains import blocklist
 from pydantic import BaseModel, EmailStr, Field, field_validator
 
-from app.models.user import User
+from app.models.user import User, UserRole
 
 
 def _reject_disposable_domain(email: EmailStr) -> EmailStr:
@@ -43,6 +43,7 @@ class UserOut(BaseModel):
     id: uuid.UUID
     email: str
     email_verified: bool
+    role: UserRole
     created_at: datetime
     last_login_at: datetime | None
 
@@ -52,6 +53,7 @@ class UserOut(BaseModel):
             id=user.id,
             email=user.email,
             email_verified=user.email_verified_at is not None,
+            role=user.role,
             created_at=user.created_at,
             last_login_at=user.last_login_at,
         )

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -1,6 +1,7 @@
+import enum
 from datetime import datetime
 
-from sqlalchemy import DateTime, String
+from sqlalchemy import DateTime, Enum, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.db.base import Base
@@ -10,6 +11,16 @@ from app.models.mixins import TimestampMixin, UUIDPkMixin
 # the plan's "explicitly out of scope" list.
 
 
+class UserRole(str, enum.Enum):
+    """Access-control role — deliberately separate from billing entitlements
+    (subscription_plans/user_subscriptions, see app/models/subscription.py). An admin doesn't need
+    a paid plan and a paid plan doesn't grant admin access; see docs/adr/20_ROLES_AND_ADMIN.md.
+    """
+
+    USER = "user"
+    ADMIN = "admin"
+
+
 class User(UUIDPkMixin, TimestampMixin, Base):
     __tablename__ = "users"
 
@@ -17,4 +28,7 @@ class User(UUIDPkMixin, TimestampMixin, Base):
     password_hash: Mapped[str] = mapped_column(String(255), nullable=False)
     email_verified_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     status: Mapped[str] = mapped_column(String(32), default="active", nullable=False)
+    role: Mapped[UserRole] = mapped_column(
+        Enum(UserRole, native_enum=False, length=16), default=UserRole.USER, nullable=False
+    )
     last_login_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/docs/adr/20_ROLES_AND_ADMIN.md
+++ b/docs/adr/20_ROLES_AND_ADMIN.md
@@ -1,0 +1,67 @@
+# Roles & Admin (MVP)
+
+## Decision: role is not subscription tier
+
+`users.role` (`app/models/user.py`) is an access-control field — what a user is allowed to *do*
+in the system. `subscription_plans` / `user_subscriptions` (`app/models/subscription.py`) is a
+billing entitlement — what a user gets for paying. These are two independent axes and must stay
+that way:
+
+- An admin does not need a paid plan.
+- A paying Pro user does not get admin access.
+- `subscription_plans.code` already has an `"ADMIN"` value (a comp/staff billing tier) — this is
+  unrelated to `users.role == "admin"`. Don't conflate the two when building billing UI/logic.
+
+`role` is a small enum (`user`, `admin` for now — see `UserRole` in `app/models/user.py`), chosen
+over a `is_admin` boolean so a future `moderator`/`support` role doesn't require another schema
+change.
+
+## How a user becomes admin
+
+No standing admin password, no seed env var read at startup. Instead:
+
+1. The account registers normally through the existing flow (email + password, argon2 hash, email
+   verification) — no new code path, no new place a plaintext password can leak.
+2. Someone with access to run commands against the deployment (`docker exec` / `railway run` /
+   local dev) runs:
+
+   ```
+   python -m app.auth.cli promote --email someone@example.com
+   python -m app.auth.cli demote --email someone@example.com
+   ```
+
+   This only requires DB access, which is already a higher trust boundary than the app itself —
+   there's no bootstrap/chicken-egg problem for the very first admin.
+
+## What's implemented
+
+- `role` column + migration (`migrations/versions/b2c3d4e5f6a7_add_user_role.py`).
+- `require_admin` FastAPI dependency (`app/auth/dependencies.py`), on top of `get_current_user`.
+- `app/auth/cli.py`: `promote`/`demote` by email.
+- Scrape job management is admin-only end to end (`app/api/v1/scrape.py`): list (`GET
+  /api/v1/scrape/jobs`, with `status`/`source_id` filters), create, cancel, and the new `retry`
+  (re-enqueues a `FAILED`/`CANCELLED` job in place). Matches the "Controls" list in
+  [13_ADMIN.md](13_ADMIN.md) as far as jobs go.
+- Minimal frontend: `/admin/jobs` (`frontend/src/pages/AdminJobsPage.tsx`), gated by
+  `frontend/src/admin/RequireAdmin.tsx` (redirects non-admins to `/`), linked from the header nav
+  only when `user.role === 'admin'`.
+
+## Explicitly deferred (backlog)
+
+Scoped out of this pass on purpose — tracked here instead of implemented, so the roles/admin
+foundation above isn't blocked on the rest of [13_ADMIN.md](13_ADMIN.md)'s dashboard:
+
+- **Admin dashboard beyond jobs**: source health (enabled/success rate/requests-per-min/challenge
+  rate), parser errors + sample raw payload, data stats (active/removed listings, snapshots,
+  storage). None of the backing metrics are collected yet either.
+- **Audit log**: 13_ADMIN.md says "any manual action is audit-logged" — not built. Every admin
+  action (promote/demote, cancel/retry a job) should eventually write to an audit table
+  (actor, action, target, timestamp).
+- **Source controls**: enable/disable a source, change crawl limits, pause a source — no
+  `sources` admin API yet.
+- **Billing-plan management CLI**: a `set-plan`-style command to manually assign/comp a
+  `subscription_plans` tier to a user, independent of `role`. Useful for support/manual grants
+  ahead of real billing integration (still Phase 5 per
+  [16_MVP_ROADMAP.md](16_MVP_ROADMAP.md)).
+- **Finer-grained roles**: `moderator`/`support` etc., if a need shows up — the enum is already
+  shaped to extend without another migration pattern change.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,7 @@
 import { Route, Routes } from 'react-router-dom'
+import { RequireAdmin } from './admin/RequireAdmin'
 import { Layout } from './components/Layout'
+import { AdminJobsPage } from './pages/AdminJobsPage'
 import { ForgotPasswordPage } from './pages/ForgotPasswordPage'
 import { ListingDetailPage } from './pages/ListingDetailPage'
 import { LoginPage } from './pages/LoginPage'
@@ -19,6 +21,9 @@ export function App() {
         <Route path="/forgot-password" element={<ForgotPasswordPage />} />
         <Route path="/reset-password" element={<ResetPasswordPage />} />
         <Route path="/verify-email" element={<VerifyEmailPage />} />
+        <Route element={<RequireAdmin />}>
+          <Route path="/admin/jobs" element={<AdminJobsPage />} />
+        </Route>
       </Route>
     </Routes>
   )

--- a/frontend/src/admin/RequireAdmin.tsx
+++ b/frontend/src/admin/RequireAdmin.tsx
@@ -1,0 +1,11 @@
+import { Navigate, Outlet } from 'react-router-dom'
+import { useCurrentUser } from '../auth/useCurrentUser'
+
+export function RequireAdmin() {
+  const { user, isLoading } = useCurrentUser()
+
+  if (isLoading) return null
+  if (!user || user.role !== 'admin') return <Navigate to="/" replace />
+
+  return <Outlet />
+}

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -30,6 +30,11 @@ export function Layout() {
           <nav className="flex items-center gap-4 text-sm">
             {isLoading ? null : user ? (
               <>
+                {user.role === 'admin' && (
+                  <Link to="/admin/jobs" className="font-medium text-slate-700 hover:text-slate-900">
+                    Задачи парсинга
+                  </Link>
+                )}
                 <span className="text-slate-600">{user.email}</span>
                 {!user.email_verified && (
                   <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800">

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2,10 +2,13 @@ import { apiFetch } from './client'
 
 export { ApiError } from './client'
 
+export type UserRole = 'user' | 'admin'
+
 export interface UserOut {
   id: string
   email: string
   email_verified: boolean
+  role: UserRole
   created_at: string
   last_login_at: string | null
 }
@@ -36,4 +39,39 @@ export const authApi = {
     }),
 
   me: () => apiFetch<UserOut>('/api/v1/me'),
+}
+
+export type ScrapeJobStatus = 'pending' | 'running' | 'completed' | 'partial' | 'failed' | 'cancelled'
+export type ScrapeJobType =
+  | 'search'
+  | 'listing_refresh'
+  | 'saved_search_refresh'
+  | 'full_source_refresh'
+  | 'market_refresh'
+
+export interface ScrapeJobOut {
+  id: string
+  source_id: string
+  job_type: ScrapeJobType
+  status: ScrapeJobStatus
+  query: Record<string, unknown> | null
+  started_at: string | null
+  finished_at: string | null
+  stats: Record<string, unknown> | null
+  error: Record<string, unknown> | null
+}
+
+export const scrapeApi = {
+  listJobs: (status?: ScrapeJobStatus) =>
+    apiFetch<ScrapeJobOut[]>(`/api/v1/scrape/jobs${status ? `?status=${status}` : ''}`),
+
+  createJob: (sourceCode: string, make?: string, maxPages = 5) =>
+    apiFetch<ScrapeJobOut>('/api/v1/scrape/jobs', {
+      method: 'POST',
+      body: JSON.stringify({ source_code: sourceCode, query: make ? { make } : {}, max_pages: maxPages }),
+    }),
+
+  cancelJob: (id: string) => apiFetch<ScrapeJobOut>(`/api/v1/scrape/jobs/${id}/cancel`, { method: 'POST' }),
+
+  retryJob: (id: string) => apiFetch<ScrapeJobOut>(`/api/v1/scrape/jobs/${id}/retry`, { method: 'POST' }),
 }

--- a/frontend/src/pages/AdminJobsPage.tsx
+++ b/frontend/src/pages/AdminJobsPage.tsx
@@ -1,0 +1,206 @@
+import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { EmptyState, ErrorState, LoadingState } from '../components/StateMessage'
+import { ApiError, type ScrapeJobStatus, scrapeApi } from '../lib/api'
+
+const STATUS_OPTIONS: { value: ScrapeJobStatus | ''; label: string }[] = [
+  { value: '', label: 'Все статусы' },
+  { value: 'pending', label: 'В очереди' },
+  { value: 'running', label: 'Выполняется' },
+  { value: 'completed', label: 'Завершено' },
+  { value: 'partial', label: 'Частично' },
+  { value: 'failed', label: 'Ошибка' },
+  { value: 'cancelled', label: 'Отменено' },
+]
+
+const RETRYABLE = new Set<ScrapeJobStatus>(['failed', 'cancelled'])
+const CANCELLABLE = new Set<ScrapeJobStatus>(['pending', 'running'])
+
+function formatTimestamp(iso: string | null): string {
+  if (!iso) return '—'
+  return new Date(iso).toLocaleString('ru-RU')
+}
+
+export function AdminJobsPage() {
+  const [statusFilter, setStatusFilter] = useState<ScrapeJobStatus | ''>('')
+  const [make, setMake] = useState('')
+  const [maxPages, setMaxPages] = useState(5)
+  const [formError, setFormError] = useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [pendingActionId, setPendingActionId] = useState<string | null>(null)
+
+  const jobsQuery = useQuery({
+    queryKey: ['admin', 'scrape-jobs', statusFilter],
+    queryFn: () => scrapeApi.listJobs(statusFilter || undefined),
+  })
+
+  async function handleCreate(event: React.FormEvent) {
+    event.preventDefault()
+    setFormError(null)
+    setIsSubmitting(true)
+    try {
+      await scrapeApi.createJob('polovniautomobili', make || undefined, maxPages)
+      setMake('')
+      await jobsQuery.refetch()
+    } catch (err) {
+      setFormError(err instanceof ApiError ? err.message : 'Не удалось создать задачу')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  async function handleCancel(id: string) {
+    setPendingActionId(id)
+    try {
+      await scrapeApi.cancelJob(id)
+      await jobsQuery.refetch()
+    } finally {
+      setPendingActionId(null)
+    }
+  }
+
+  async function handleRetry(id: string) {
+    setPendingActionId(id)
+    try {
+      await scrapeApi.retryJob(id)
+      await jobsQuery.refetch()
+    } finally {
+      setPendingActionId(null)
+    }
+  }
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <h1 className="text-xl font-semibold text-slate-900">Задачи парсинга</h1>
+        <p className="mt-1 text-sm text-slate-600">Создание и управление задачами сбора объявлений.</p>
+      </div>
+
+      <form onSubmit={handleCreate} className="rounded-lg border border-slate-200 bg-white p-4">
+        <h2 className="mb-3 text-sm font-medium text-slate-900">Новая задача</h2>
+        {formError && <p className="mb-3 text-sm text-red-600">{formError}</p>}
+        <div className="flex flex-wrap items-end gap-3">
+          <div>
+            <label className="mb-1 block text-xs font-medium text-slate-600" htmlFor="job-source">
+              Источник
+            </label>
+            <select
+              id="job-source"
+              disabled
+              value="polovniautomobili"
+              className="rounded-md border border-slate-300 bg-slate-50 px-3 py-1.5 text-sm text-slate-700"
+            >
+              <option value="polovniautomobili">Polovni Automobili</option>
+            </select>
+          </div>
+          <div>
+            <label className="mb-1 block text-xs font-medium text-slate-600" htmlFor="job-make">
+              Марка (опционально)
+            </label>
+            <input
+              id="job-make"
+              value={make}
+              onChange={(e) => setMake(e.target.value)}
+              placeholder="Skoda"
+              className="rounded-md border border-slate-300 px-3 py-1.5 text-sm"
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-xs font-medium text-slate-600" htmlFor="job-max-pages">
+              Макс. страниц
+            </label>
+            <input
+              id="job-max-pages"
+              type="number"
+              min={1}
+              max={50}
+              value={maxPages}
+              onChange={(e) => setMaxPages(Number(e.target.value))}
+              className="w-24 rounded-md border border-slate-300 px-3 py-1.5 text-sm"
+            />
+          </div>
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className="rounded-md bg-slate-900 px-4 py-1.5 text-sm font-medium text-white hover:bg-slate-700 disabled:opacity-50"
+          >
+            {isSubmitting ? 'Создаём…' : 'Запустить'}
+          </button>
+        </div>
+      </form>
+
+      <div>
+        <div className="mb-3 flex items-center justify-between">
+          <h2 className="text-sm font-medium text-slate-900">Все задачи</h2>
+          <select
+            value={statusFilter}
+            onChange={(e) => setStatusFilter(e.target.value as ScrapeJobStatus | '')}
+            className="rounded-md border border-slate-300 px-3 py-1.5 text-sm"
+          >
+            {STATUS_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {jobsQuery.isLoading && <LoadingState />}
+        {jobsQuery.isError && <ErrorState message="Не удалось загрузить задачи" onRetry={() => jobsQuery.refetch()} />}
+        {jobsQuery.isSuccess && jobsQuery.data.length === 0 && <EmptyState message="Задач пока нет" />}
+
+        {jobsQuery.isSuccess && jobsQuery.data.length > 0 && (
+          <div className="overflow-x-auto rounded-lg border border-slate-200 bg-white">
+            <table className="w-full text-left text-sm">
+              <thead className="border-b border-slate-200 bg-slate-50 text-xs uppercase text-slate-500">
+                <tr>
+                  <th className="px-4 py-2">Тип</th>
+                  <th className="px-4 py-2">Статус</th>
+                  <th className="px-4 py-2">Начало</th>
+                  <th className="px-4 py-2">Конец</th>
+                  <th className="px-4 py-2">Ошибка</th>
+                  <th className="px-4 py-2" />
+                </tr>
+              </thead>
+              <tbody>
+                {jobsQuery.data.map((job) => (
+                  <tr key={job.id} className="border-b border-slate-100 last:border-0">
+                    <td className="px-4 py-2 text-slate-700">{job.job_type}</td>
+                    <td className="px-4 py-2 text-slate-700">{job.status}</td>
+                    <td className="px-4 py-2 text-slate-500">{formatTimestamp(job.started_at)}</td>
+                    <td className="px-4 py-2 text-slate-500">{formatTimestamp(job.finished_at)}</td>
+                    <td className="px-4 py-2 max-w-xs truncate text-slate-500">
+                      {job.error ? JSON.stringify(job.error) : '—'}
+                    </td>
+                    <td className="px-4 py-2 text-right">
+                      {CANCELLABLE.has(job.status) && (
+                        <button
+                          type="button"
+                          disabled={pendingActionId === job.id}
+                          onClick={() => handleCancel(job.id)}
+                          className="rounded-md border border-slate-300 px-2 py-1 text-xs font-medium text-slate-700 hover:bg-slate-100 disabled:opacity-50"
+                        >
+                          Отменить
+                        </button>
+                      )}
+                      {RETRYABLE.has(job.status) && (
+                        <button
+                          type="button"
+                          disabled={pendingActionId === job.id}
+                          onClick={() => handleRetry(job.id)}
+                          className="ml-2 rounded-md border border-slate-300 px-2 py-1 text-xs font-medium text-slate-700 hover:bg-slate-100 disabled:opacity-50"
+                        >
+                          Повторить
+                        </button>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/migrations/versions/b2c3d4e5f6a7_add_user_role.py
+++ b/migrations/versions/b2c3d4e5f6a7_add_user_role.py
@@ -1,0 +1,27 @@
+"""add user role
+
+Revision ID: b2c3d4e5f6a7
+Revises: a1b2c3d4e5f6
+Create Date: 2026-09-09 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'b2c3d4e5f6a7'
+down_revision: Union[str, Sequence[str], None] = 'a1b2c3d4e5f6'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('users', sa.Column('role', sa.String(length=16), nullable=False, server_default='user'))
+    op.alter_column('users', 'role', server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_column('users', 'role')

--- a/tests/unit/test_auth_cli.py
+++ b/tests/unit/test_auth_cli.py
@@ -1,0 +1,40 @@
+import pytest
+
+from app.auth.cli import _set_role
+from app.auth.repository import UserRepository
+from app.models.user import UserRole
+
+
+@pytest.fixture(autouse=True)
+def _patch_get_session(monkeypatch, session):
+    async def fake_get_session():
+        yield session
+
+    monkeypatch.setattr("app.auth.cli.get_session", fake_get_session)
+
+
+async def test_promote_sets_admin_role(session):
+    user = await UserRepository(session).create("person@example.com", "hashed")
+    await session.commit()
+    assert user.role == UserRole.USER
+
+    await _set_role("person@example.com", UserRole.ADMIN)
+
+    refreshed = await UserRepository(session).get_by_email("person@example.com")
+    assert refreshed.role == UserRole.ADMIN
+
+
+async def test_demote_resets_user_role(session):
+    user = await UserRepository(session).create("person@example.com", "hashed")
+    await UserRepository(session).set_role(user, UserRole.ADMIN)
+    await session.commit()
+
+    await _set_role("person@example.com", UserRole.USER)
+
+    refreshed = await UserRepository(session).get_by_email("person@example.com")
+    assert refreshed.role == UserRole.USER
+
+
+async def test_set_role_raises_for_unknown_email(session):
+    with pytest.raises(SystemExit):
+        await _set_role("nobody@example.com", UserRole.ADMIN)

--- a/tests/unit/test_scrape_endpoints.py
+++ b/tests/unit/test_scrape_endpoints.py
@@ -10,12 +10,14 @@ from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlalchemy.pool import StaticPool
 
 from app.auth.email import get_email_sender
+from app.auth.repository import UserRepository
 from app.config import get_settings
 from app.db.base import Base
 from app.db.session import get_session
 from app.infrastructure.redis import get_redis
 from app.main import app
 from app.models.scrape_job import ScrapeJobStatus
+from app.models.user import UserRole
 from app.scraping.queue import get_job_enqueuer
 
 
@@ -49,14 +51,19 @@ def enqueuer():
 
 
 @pytest_asyncio.fixture
-async def client(email_sender, enqueuer):
+async def session_factory():
     engine = create_async_engine(
         "sqlite+aiosqlite:///:memory:", poolclass=StaticPool, connect_args={"check_same_thread": False}
     )
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
-    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    yield factory
+    await engine.dispose()
 
+
+@pytest_asyncio.fixture
+async def client(session_factory, email_sender, enqueuer):
     async def override_get_session():
         async with session_factory() as session:
             yield session
@@ -74,7 +81,6 @@ async def client(email_sender, enqueuer):
 
     app.dependency_overrides.clear()
     await fake_redis.aclose()
-    await engine.dispose()
 
 
 def _csrf_headers(client: AsyncClient) -> dict[str, str]:
@@ -82,15 +88,39 @@ def _csrf_headers(client: AsyncClient) -> dict[str, str]:
     return {settings.csrf_header_name: client.cookies[settings.csrf_cookie_name]}
 
 
-async def _register_and_login(client: AsyncClient, email_sender: RecordingEmailSender) -> None:
-    await client.post("/api/v1/auth/register", json={"email": "scraper@example.com", "password": "hunter2pass"})
+async def _register_and_login(
+    client: AsyncClient,
+    email_sender: RecordingEmailSender,
+    email: str = "scraper@example.com",
+) -> None:
+    await client.post("/api/v1/auth/register", json={"email": email, "password": "hunter2pass"})
     token = email_sender.last_token()
     await client.post("/api/v1/auth/verify-email", json={"token": token})
-    await client.post("/api/v1/auth/login", json={"email": "scraper@example.com", "password": "hunter2pass"})
+    await client.post("/api/v1/auth/login", json={"email": email, "password": "hunter2pass"})
 
 
-async def test_create_scrape_job_creates_row_and_enqueues(client, email_sender, enqueuer):
-    await _register_and_login(client, email_sender)
+async def _promote_to_admin(session_factory, email: str = "scraper@example.com") -> None:
+    async with session_factory() as session:
+        repo = UserRepository(session)
+        user = await repo.get_by_email(email)
+        await repo.set_role(user, UserRole.ADMIN)
+        await session.commit()
+
+
+async def _register_login_and_promote(
+    client: AsyncClient,
+    email_sender: RecordingEmailSender,
+    session_factory,
+    email: str = "scraper@example.com",
+) -> None:
+    await _register_and_login(client, email_sender, email)
+    # get_current_user re-fetches the user row on every request, so the promotion above takes
+    # effect immediately without a re-login.
+    await _promote_to_admin(session_factory, email)
+
+
+async def test_create_scrape_job_creates_row_and_enqueues(client, email_sender, session_factory, enqueuer):
+    await _register_login_and_promote(client, email_sender, session_factory)
 
     response = await client.post(
         "/api/v1/scrape/jobs",
@@ -106,8 +136,8 @@ async def test_create_scrape_job_creates_row_and_enqueues(client, email_sender, 
     assert enqueuer.enqueued == [body["id"]]
 
 
-async def test_create_scrape_job_rejects_unknown_source(client, email_sender):
-    await _register_and_login(client, email_sender)
+async def test_create_scrape_job_rejects_unknown_source(client, email_sender, session_factory):
+    await _register_login_and_promote(client, email_sender, session_factory)
 
     response = await client.post(
         "/api/v1/scrape/jobs",
@@ -123,8 +153,18 @@ async def test_create_scrape_job_requires_auth(client):
     assert response.status_code == 401
 
 
-async def test_get_scrape_job_returns_created_job(client, email_sender):
+async def test_create_scrape_job_requires_admin(client, email_sender):
     await _register_and_login(client, email_sender)
+
+    response = await client.post(
+        "/api/v1/scrape/jobs", json={"source_code": "polovniautomobili"}, headers=_csrf_headers(client)
+    )
+
+    assert response.status_code == 403
+
+
+async def test_get_scrape_job_returns_created_job(client, email_sender, session_factory):
+    await _register_login_and_promote(client, email_sender, session_factory)
     create_response = await client.post(
         "/api/v1/scrape/jobs", json={"source_code": "polovniautomobili"}, headers=_csrf_headers(client)
     )
@@ -136,14 +176,14 @@ async def test_get_scrape_job_returns_created_job(client, email_sender):
     assert response.json()["id"] == job_id
 
 
-async def test_get_scrape_job_404_for_unknown_id(client, email_sender):
-    await _register_and_login(client, email_sender)
+async def test_get_scrape_job_404_for_unknown_id(client, email_sender, session_factory):
+    await _register_login_and_promote(client, email_sender, session_factory)
     response = await client.get("/api/v1/scrape/jobs/00000000-0000-0000-0000-000000000000")
     assert response.status_code == 404
 
 
-async def test_cancel_scrape_job_flips_status(client, email_sender):
-    await _register_and_login(client, email_sender)
+async def test_cancel_scrape_job_flips_status(client, email_sender, session_factory):
+    await _register_login_and_promote(client, email_sender, session_factory)
     create_response = await client.post(
         "/api/v1/scrape/jobs", json={"source_code": "polovniautomobili"}, headers=_csrf_headers(client)
     )
@@ -153,3 +193,54 @@ async def test_cancel_scrape_job_flips_status(client, email_sender):
 
     assert response.status_code == 200
     assert response.json()["status"] == ScrapeJobStatus.CANCELLED.value
+
+
+async def test_retry_scrape_job_reenqueues_failed_job(client, email_sender, session_factory, enqueuer):
+    await _register_login_and_promote(client, email_sender, session_factory)
+    create_response = await client.post(
+        "/api/v1/scrape/jobs", json={"source_code": "polovniautomobili"}, headers=_csrf_headers(client)
+    )
+    job_id = create_response.json()["id"]
+    await client.post(f"/api/v1/scrape/jobs/{job_id}/cancel", headers=_csrf_headers(client))
+
+    response = await client.post(f"/api/v1/scrape/jobs/{job_id}/retry", headers=_csrf_headers(client))
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == ScrapeJobStatus.PENDING.value
+    assert body["finished_at"] is None
+    assert enqueuer.enqueued == [job_id, job_id]
+
+
+async def test_retry_scrape_job_rejects_non_terminal_job(client, email_sender, session_factory):
+    await _register_login_and_promote(client, email_sender, session_factory)
+    create_response = await client.post(
+        "/api/v1/scrape/jobs", json={"source_code": "polovniautomobili"}, headers=_csrf_headers(client)
+    )
+    job_id = create_response.json()["id"]
+
+    response = await client.post(f"/api/v1/scrape/jobs/{job_id}/retry", headers=_csrf_headers(client))
+
+    assert response.status_code == 400
+
+
+async def test_list_scrape_jobs_filters_by_status(client, email_sender, session_factory):
+    await _register_login_and_promote(client, email_sender, session_factory)
+    create_response = await client.post(
+        "/api/v1/scrape/jobs", json={"source_code": "polovniautomobili"}, headers=_csrf_headers(client)
+    )
+    job_id = create_response.json()["id"]
+    await client.post(f"/api/v1/scrape/jobs/{job_id}/cancel", headers=_csrf_headers(client))
+    await client.post("/api/v1/scrape/jobs", json={"source_code": "polovniautomobili"}, headers=_csrf_headers(client))
+
+    response = await client.get("/api/v1/scrape/jobs", params={"status": ScrapeJobStatus.CANCELLED.value})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert [job["id"] for job in body] == [job_id]
+
+
+async def test_list_scrape_jobs_requires_admin(client, email_sender):
+    await _register_and_login(client, email_sender)
+    response = await client.get("/api/v1/scrape/jobs")
+    assert response.status_code == 403


### PR DESCRIPTION
## Summary
- Adds `users.role` (`user`/`admin`), kept deliberately separate from `subscription_plans` billing tiers so it doesn't conflict with future monetization — see [docs/adr/20_ROLES_AND_ADMIN.md](docs/adr/20_ROLES_AND_ADMIN.md).
- Root/admin access has no standing password: an account registers normally, then `python -m app.auth.cli promote/demote --email` flips its role.
- Scrape job management (`GET /api/v1/scrape/jobs` list — new, plus create/cancel/retry — retry is new) is now admin-only end to end.
- Minimal `/admin/jobs` frontend page to drive it: create job, filter by status, cancel/retry, with a route guard redirecting non-admins.

## Test plan
- [x] `pytest` — 112 passed
- [x] `ruff check` / `mypy app` — clean
- [x] `tsc -b` / `oxlint` — clean
- [x] Manually verified end-to-end in browser against local Postgres/Redis: register → `promote` via CLI → nav link appears → create job → cancel → retry → `demote` blocks `/admin/jobs` (redirects to `/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)