### PR TITLE
Fix users.role storage mismatch that broke every read after the role migration

### DIFF
--- a/migrations/versions/b2c3d4e5f6a7_add_user_role.py
+++ b/migrations/versions/b2c3d4e5f6a7_add_user_role.py
@@ -19,7 +19,15 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    op.add_column('users', sa.Column('role', sa.String(length=16), nullable=False, server_default='user'))
+    op.add_column(
+        'users',
+        sa.Column(
+            'role',
+            sa.Enum('USER', 'ADMIN', name='userrole', native_enum=False, length=16),
+            nullable=False,
+            server_default='USER',
+        ),
+    )
     op.alter_column('users', 'role', server_default=None)
 
 

--- a/migrations/versions/c3d4e5f6a7b8_normalize_user_role_values.py
+++ b/migrations/versions/c3d4e5f6a7b8_normalize_user_role_values.py
@@ -1,0 +1,36 @@
+"""normalize user role values
+
+Revision ID: c3d4e5f6a7b8
+Revises: b2c3d4e5f6a7
+Create Date: 2026-09-10 00:00:00.000000
+
+The previous migration's server_default wrote the lowercase enum *value* ('user') rather than
+the enum *name* ('USER') that Enum(..., native_enum=False) expects on read (matching every other
+enum column in this schema — see listingstatus/notificationtype/scrapejobtype/scrapejobstatus in
+6893edef29c3_initial_schema.py). Any row written before that fix has an unreadable role. This
+normalizes existing data; a no-op on a DB that never saw the buggy default.
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'c3d4e5f6a7b8'
+down_revision: Union[str, Sequence[str], None] = 'b2c3d4e5f6a7'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    users = sa.table('users', sa.column('role', sa.String))
+    op.execute(users.update().where(users.c.role == 'user').values(role='USER'))
+    op.execute(users.update().where(users.c.role == 'admin').values(role='ADMIN'))
+
+
+def downgrade() -> None:
+    users = sa.table('users', sa.column('role', sa.String))
+    op.execute(users.update().where(users.c.role == 'USER').values(role='user'))
+    op.execute(users.update().where(users.c.role == 'ADMIN').values(role='admin'))


### PR DESCRIPTION
## Summary
- Root cause: the `role` migration ([#71](https://github.com/sityaevDI/car-ad-scraper/pull/71)) backfilled existing rows via `server_default='user'` — the lowercase enum *value*. But `Enum(UserRole, native_enum=False)` reads/writes by member *name* (`'USER'`) by default, same as every other enum column in this schema (listing status, notification type, scrape job type/status). Any row touched by that default became unreadable — e.g. `python -m app.auth.cli promote` crashed with `LookupError: 'user' is not among the defined enum values`.
- Fixes `b2c3d4e5f6a7_add_user_role.py` to declare the column as `sa.Enum('USER', 'ADMIN', ...)` with an uppercase `server_default`, matching sibling migrations.
- Adds `c3d4e5f6a7b8_normalize_user_role_values.py` to fix any row already written with the broken lowercase default on environments where the buggy migration already ran (a no-op elsewhere).

## Test plan
- [x] `pytest` — 112 passed, `ruff check`, `mypy app` — clean
- [x] Fresh DB: `alembic upgrade head` from scratch, register + `promote`/`demote` via CLI — works
- [x] Reproduced the bug: downgraded to the broken migration, manually corrupted a row's role to lowercase (as the original server_default would have), then `alembic upgrade head` and confirmed the row reads back correctly and CLI promote/demote work afterward

## Rollout note
Any already-deployed environment needs `alembic upgrade head` re-run to pick up the normalize migration (Railway's Dockerfile CMD does this automatically on deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)