### PR TITLE
Fix CSRF cookie scoping across subdomains

### DIFF
--- a/app/api/v1/auth.py
+++ b/app/api/v1/auth.py
@@ -40,6 +40,7 @@ def _set_auth_cookies(response: Response, session_id: str) -> None:
         session_id,
         max_age=settings.session_ttl_seconds,
         path="/",
+        domain=settings.cookie_domain,
         secure=settings.cookie_secure,
         httponly=True,
         samesite="lax",
@@ -50,6 +51,7 @@ def _set_auth_cookies(response: Response, session_id: str) -> None:
         csrf_token,
         max_age=settings.session_ttl_seconds,
         path="/",
+        domain=settings.cookie_domain,
         secure=settings.cookie_secure,
         httponly=False,
         samesite="lax",
@@ -58,8 +60,8 @@ def _set_auth_cookies(response: Response, session_id: str) -> None:
 
 def _clear_auth_cookies(response: Response) -> None:
     settings = get_settings()
-    response.delete_cookie(settings.session_cookie_name, path="/")
-    response.delete_cookie(settings.csrf_cookie_name, path="/")
+    response.delete_cookie(settings.session_cookie_name, path="/", domain=settings.cookie_domain)
+    response.delete_cookie(settings.csrf_cookie_name, path="/", domain=settings.cookie_domain)
 
 
 @router.post("/register", response_model=UserOut, status_code=201)

--- a/app/config.py
+++ b/app/config.py
@@ -20,6 +20,10 @@ class Settings(BaseSettings):
     csrf_cookie_name: str = "csrf_token"
     csrf_header_name: str = "X-CSRF-Token"
     cookie_secure: bool = False
+    # Set to a parent domain (e.g. ".carradar.rs") when the frontend and API live on different
+    # subdomains, so the browser shares auth cookies between them. Unset -> host-only cookies,
+    # which only work when frontend and API share the exact same hostname.
+    cookie_domain: str | None = None
     session_ttl_seconds: int = 60 * 60 * 24 * 14
     email_verification_ttl_seconds: int = 60 * 60 * 24
     password_reset_ttl_seconds: int = 60 * 30


### PR DESCRIPTION
## Summary
- Auth/CSRF cookies were host-only (no `Domain` attribute), so the frontend's `document.cookie` read of `csrf_token` silently failed whenever the frontend and API are served from different subdomains (e.g. `www.carradar.rs` vs `api.carradar.rs`), causing every mutating request (e.g. creating scrape jobs) to fail with `403 CSRF token missing or invalid`.
- Adds a `cookie_domain` setting (env: `COOKIE_DOMAIN`) so cookies can be scoped to a shared parent domain (e.g. `.carradar.rs`) in production; defaults to `None` (host-only, current behavior) for local dev.

## Test plan
- [ ] Set `COOKIE_DOMAIN=.carradar.rs` in the production environment
- [ ] Log in on `carradar.rs`, confirm `csrf_token` cookie has `Domain=.carradar.rs` in dev tools
- [ ] Create/manage a scrape job and confirm no more `CSRF token missing or invalid` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)