### PR TITLE
Add interval-based scheduling for scrape jobs

### DIFF
--- a/app/api/v1/scrape.py
+++ b/app/api/v1/scrape.py
@@ -9,11 +9,19 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth.dependencies import require_admin, require_csrf
 from app.db.session import get_session
+from app.models.scheduled_scrape import ScheduledScrape
 from app.models.scrape_job import ScrapeJob, ScrapeJobStatus, ScrapeJobType
 from app.models.user import User
 from app.scraping.pipeline import get_or_create_source
 from app.scraping.queue import get_arq_pool, get_job_enqueuer
-from app.scraping.schemas import ScrapeJobCreate, ScrapeJobOut, encode_job_query
+from app.scraping.schemas import (
+    ScheduledScrapeCreate,
+    ScheduledScrapeOut,
+    ScheduledScrapeUpdate,
+    ScrapeJobCreate,
+    ScrapeJobOut,
+    encode_job_query,
+)
 from app.sources.registry import SOURCE_REGISTRY
 
 # Job management is an admin action (docs/adr/13_ADMIN.md "Controls"), not a regular-user
@@ -148,3 +156,76 @@ async def retry_scrape_job(
 
     await enqueue(str(job.id))
     return ScrapeJobOut.model_validate(job)
+
+
+@router.get("/schedules", response_model=list[ScheduledScrapeOut])
+async def list_scheduled_scrapes(
+    session: AsyncSession = Depends(get_session),
+    _current_user: User = Depends(require_admin),
+) -> list[ScheduledScrapeOut]:
+    stmt = select(ScheduledScrape).order_by(ScheduledScrape.created_at.desc())
+    schedules = (await session.execute(stmt)).scalars().all()
+    return [ScheduledScrapeOut.model_validate(s) for s in schedules]
+
+
+@router.post("/schedules", response_model=ScheduledScrapeOut, status_code=201)
+async def create_scheduled_scrape(
+    payload: ScheduledScrapeCreate,
+    session: AsyncSession = Depends(get_session),
+    _current_user: User = Depends(require_admin),
+    _csrf: None = Depends(require_csrf),
+) -> ScheduledScrapeOut:
+    adapter_cls = SOURCE_REGISTRY.get(payload.source_code)
+    if adapter_cls is None:
+        raise HTTPException(status_code=400, detail=f"Unknown source_code: {payload.source_code!r}")
+
+    source = await get_or_create_source(
+        session,
+        code=adapter_cls.source_code,
+        name=adapter_cls.display_name,
+        domain=adapter_cls.domain,
+        country=adapter_cls.country,
+    )
+    schedule = ScheduledScrape(
+        source_id=source.id,
+        query=encode_job_query(payload.query, payload.max_pages),
+        interval_minutes=payload.interval_minutes,
+        next_run_at=payload.start_at or datetime.now(timezone.utc),
+    )
+    session.add(schedule)
+    await session.commit()
+    return ScheduledScrapeOut.model_validate(schedule)
+
+
+@router.patch("/schedules/{schedule_id}", response_model=ScheduledScrapeOut)
+async def update_scheduled_scrape(
+    schedule_id: uuid.UUID,
+    payload: ScheduledScrapeUpdate,
+    session: AsyncSession = Depends(get_session),
+    _current_user: User = Depends(require_admin),
+    _csrf: None = Depends(require_csrf),
+) -> ScheduledScrapeOut:
+    schedule = await session.get(ScheduledScrape, schedule_id)
+    if schedule is None:
+        raise HTTPException(status_code=404, detail="Schedule not found")
+
+    if payload.interval_minutes is not None:
+        schedule.interval_minutes = payload.interval_minutes
+    if payload.enabled is not None:
+        schedule.enabled = payload.enabled
+    await session.commit()
+    return ScheduledScrapeOut.model_validate(schedule)
+
+
+@router.delete("/schedules/{schedule_id}", status_code=204)
+async def delete_scheduled_scrape(
+    schedule_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    _current_user: User = Depends(require_admin),
+    _csrf: None = Depends(require_csrf),
+) -> None:
+    schedule = await session.get(ScheduledScrape, schedule_id)
+    if schedule is None:
+        raise HTTPException(status_code=404, detail="Schedule not found")
+    await session.delete(schedule)
+    await session.commit()

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -3,6 +3,7 @@
 from app.models.listing import Listing, ListingStatus
 from app.models.notification import Notification, NotificationType
 from app.models.saved_search import SavedSearch
+from app.models.scheduled_scrape import ScheduledScrape
 from app.models.scrape_job import ScrapeJob, ScrapeJobStatus, ScrapeJobType
 from app.models.snapshot import ListingSnapshot
 from app.models.source import Source
@@ -18,6 +19,7 @@ __all__ = [
     "ListingSnapshot",
     "User",
     "SavedSearch",
+    "ScheduledScrape",
     "ScrapeJob",
     "ScrapeJobStatus",
     "ScrapeJobType",

--- a/app/models/scheduled_scrape.py
+++ b/app/models/scheduled_scrape.py
@@ -1,0 +1,24 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import JSON, Boolean, DateTime, ForeignKey, Integer, Uuid
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+from app.models.mixins import TimestampMixin, UUIDPkMixin
+
+# A standalone admin-defined "run this query every N minutes" schedule — deliberately not tied to
+# SavedSearch/subscription plans (see docs/adr/20_ROLES_AND_ADMIN.md and issue #26, which is the
+# bigger per-user/per-plan saved-search refresh scheduler this is not attempting to replace).
+
+
+class ScheduledScrape(UUIDPkMixin, TimestampMixin, Base):
+    __tablename__ = "scheduled_scrapes"
+
+    source_id: Mapped[uuid.UUID] = mapped_column(Uuid, ForeignKey("sources.id"), nullable=False)
+    query: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    interval_minutes: Mapped[int] = mapped_column(Integer, nullable=False)
+    enabled: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    next_run_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    last_run_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    last_job_id: Mapped[uuid.UUID | None] = mapped_column(Uuid, ForeignKey("scrape_jobs.id"), nullable=True)

--- a/app/scraping/scheduler.py
+++ b/app/scraping/scheduler.py
@@ -1,0 +1,38 @@
+"""arq cron job: creates and enqueues a ScrapeJob for every due ScheduledScrape, then advances
+next_run_at. Runs inside the same worker process as run_scrape_job (see app/scraping/worker.py) —
+no separate scheduler container needed for this simple, interval-based schedule.
+"""
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from sqlalchemy import select
+
+from app.models.scheduled_scrape import ScheduledScrape
+from app.models.scrape_job import ScrapeJob, ScrapeJobStatus, ScrapeJobType
+
+
+async def run_due_scheduled_scrapes(ctx: dict[str, Any]) -> None:
+    session_factory = ctx["session_factory"]
+    now = datetime.now(timezone.utc)
+
+    async with session_factory() as session:
+        stmt = select(ScheduledScrape).where(ScheduledScrape.enabled.is_(True), ScheduledScrape.next_run_at <= now)
+        due = (await session.execute(stmt)).scalars().all()
+
+        for scheduled in due:
+            job = ScrapeJob(
+                source_id=scheduled.source_id,
+                job_type=ScrapeJobType.SEARCH,
+                status=ScrapeJobStatus.PENDING,
+                query=scheduled.query,
+            )
+            session.add(job)
+            await session.flush()
+
+            scheduled.last_run_at = now
+            scheduled.next_run_at = now + timedelta(minutes=scheduled.interval_minutes)
+            scheduled.last_job_id = job.id
+            await session.commit()
+
+            await ctx["redis"].enqueue_job("run_scrape_job", str(job.id))

--- a/app/scraping/schemas.py
+++ b/app/scraping/schemas.py
@@ -6,14 +6,13 @@ from pydantic import BaseModel, ConfigDict, Field
 from app.models.scrape_job import ScrapeJobStatus, ScrapeJobType
 from app.search.query import SearchQuery
 
+_DEFAULT_MAX_PAGES = 5
+
 
 class ScrapeJobCreate(BaseModel):
     source_code: str
     query: SearchQuery = Field(default_factory=SearchQuery)
     max_pages: int = 5
-
-
-_DEFAULT_MAX_PAGES = 5
 
 
 def encode_job_query(query: SearchQuery, max_pages: int) -> dict:
@@ -43,3 +42,29 @@ class ScrapeJobOut(BaseModel):
     finished_at: datetime | None
     stats: dict | None
     error: dict | None
+
+
+class ScheduledScrapeCreate(BaseModel):
+    source_code: str
+    query: SearchQuery = Field(default_factory=SearchQuery)
+    max_pages: int = 5
+    interval_minutes: int = Field(ge=5)
+    start_at: datetime | None = None
+
+
+class ScheduledScrapeUpdate(BaseModel):
+    interval_minutes: int | None = Field(default=None, ge=5)
+    enabled: bool | None = None
+
+
+class ScheduledScrapeOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    source_id: uuid.UUID
+    query: dict | None
+    interval_minutes: int
+    enabled: bool
+    next_run_at: datetime
+    last_run_at: datetime | None
+    last_job_id: uuid.UUID | None

--- a/app/scraping/worker.py
+++ b/app/scraping/worker.py
@@ -9,6 +9,7 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any
 
+from arq import cron
 from arq.connections import RedisSettings
 
 from app.config import get_settings
@@ -17,6 +18,7 @@ from app.models.scrape_job import ScrapeJob, ScrapeJobStatus
 from app.models.source import Source
 from app.scraping.pipeline import run_scrape
 from app.scraping.proxy import get_proxy_provider
+from app.scraping.scheduler import run_due_scheduled_scrapes
 from app.scraping.schemas import decode_job_query
 
 
@@ -70,5 +72,6 @@ async def run_scrape_job(ctx: dict[str, Any], job_id: str) -> None:
 
 class WorkerSettings:
     functions = [run_scrape_job]
+    cron_jobs = [cron(run_due_scheduled_scrapes, second=0)]
     on_startup = _on_startup
     redis_settings = RedisSettings.from_dsn(get_settings().redis_url)

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -74,4 +74,36 @@ export const scrapeApi = {
   cancelJob: (id: string) => apiFetch<ScrapeJobOut>(`/api/v1/scrape/jobs/${id}/cancel`, { method: 'POST' }),
 
   retryJob: (id: string) => apiFetch<ScrapeJobOut>(`/api/v1/scrape/jobs/${id}/retry`, { method: 'POST' }),
+
+  listSchedules: () => apiFetch<ScheduledScrapeOut[]>('/api/v1/scrape/schedules'),
+
+  createSchedule: (sourceCode: string, intervalMinutes: number, make?: string, maxPages = 5) =>
+    apiFetch<ScheduledScrapeOut>('/api/v1/scrape/schedules', {
+      method: 'POST',
+      body: JSON.stringify({
+        source_code: sourceCode,
+        query: make ? { make } : {},
+        max_pages: maxPages,
+        interval_minutes: intervalMinutes,
+      }),
+    }),
+
+  updateSchedule: (id: string, update: { enabled?: boolean; interval_minutes?: number }) =>
+    apiFetch<ScheduledScrapeOut>(`/api/v1/scrape/schedules/${id}`, {
+      method: 'PATCH',
+      body: JSON.stringify(update),
+    }),
+
+  deleteSchedule: (id: string) => apiFetch<void>(`/api/v1/scrape/schedules/${id}`, { method: 'DELETE' }),
+}
+
+export interface ScheduledScrapeOut {
+  id: string
+  source_id: string
+  query: Record<string, unknown> | null
+  interval_minutes: number
+  enabled: boolean
+  next_run_at: string
+  last_run_at: string | null
+  last_job_id: string | null
 }

--- a/frontend/src/pages/AdminJobsPage.tsx
+++ b/frontend/src/pages/AdminJobsPage.tsx
@@ -29,9 +29,21 @@ export function AdminJobsPage() {
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [pendingActionId, setPendingActionId] = useState<string | null>(null)
 
+  const [scheduleMake, setScheduleMake] = useState('')
+  const [scheduleMaxPages, setScheduleMaxPages] = useState(5)
+  const [intervalHours, setIntervalHours] = useState(6)
+  const [scheduleFormError, setScheduleFormError] = useState<string | null>(null)
+  const [isCreatingSchedule, setIsCreatingSchedule] = useState(false)
+  const [pendingScheduleId, setPendingScheduleId] = useState<string | null>(null)
+
   const jobsQuery = useQuery({
     queryKey: ['admin', 'scrape-jobs', statusFilter],
     queryFn: () => scrapeApi.listJobs(statusFilter || undefined),
+  })
+
+  const schedulesQuery = useQuery({
+    queryKey: ['admin', 'scheduled-scrapes'],
+    queryFn: scrapeApi.listSchedules,
   })
 
   async function handleCreate(event: React.FormEvent) {
@@ -66,6 +78,41 @@ export function AdminJobsPage() {
       await jobsQuery.refetch()
     } finally {
       setPendingActionId(null)
+    }
+  }
+
+  async function handleCreateSchedule(event: React.FormEvent) {
+    event.preventDefault()
+    setScheduleFormError(null)
+    setIsCreatingSchedule(true)
+    try {
+      await scrapeApi.createSchedule('polovniautomobili', intervalHours * 60, scheduleMake || undefined, scheduleMaxPages)
+      setScheduleMake('')
+      await schedulesQuery.refetch()
+    } catch (err) {
+      setScheduleFormError(err instanceof ApiError ? err.message : 'Не удалось создать расписание')
+    } finally {
+      setIsCreatingSchedule(false)
+    }
+  }
+
+  async function handleToggleSchedule(id: string, enabled: boolean) {
+    setPendingScheduleId(id)
+    try {
+      await scrapeApi.updateSchedule(id, { enabled: !enabled })
+      await schedulesQuery.refetch()
+    } finally {
+      setPendingScheduleId(null)
+    }
+  }
+
+  async function handleDeleteSchedule(id: string) {
+    setPendingScheduleId(id)
+    try {
+      await scrapeApi.deleteSchedule(id)
+      await schedulesQuery.refetch()
+    } finally {
+      setPendingScheduleId(null)
     }
   }
 
@@ -193,6 +240,118 @@ export function AdminJobsPage() {
                           Повторить
                         </button>
                       )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      <div>
+        <h2 className="mb-1 text-sm font-medium text-slate-900">Расписания</h2>
+        <p className="mb-3 text-sm text-slate-600">
+          Регулярный запуск задачи с заданным интервалом — держит данные актуальными без ручных запусков.
+        </p>
+
+        <form onSubmit={handleCreateSchedule} className="mb-4 rounded-lg border border-slate-200 bg-white p-4">
+          {scheduleFormError && <p className="mb-3 text-sm text-red-600">{scheduleFormError}</p>}
+          <div className="flex flex-wrap items-end gap-3">
+            <div>
+              <label className="mb-1 block text-xs font-medium text-slate-600" htmlFor="schedule-make">
+                Марка (опционально)
+              </label>
+              <input
+                id="schedule-make"
+                value={scheduleMake}
+                onChange={(e) => setScheduleMake(e.target.value)}
+                placeholder="Skoda"
+                className="rounded-md border border-slate-300 px-3 py-1.5 text-sm"
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-xs font-medium text-slate-600" htmlFor="schedule-max-pages">
+                Макс. страниц
+              </label>
+              <input
+                id="schedule-max-pages"
+                type="number"
+                min={1}
+                max={50}
+                value={scheduleMaxPages}
+                onChange={(e) => setScheduleMaxPages(Number(e.target.value))}
+                className="w-24 rounded-md border border-slate-300 px-3 py-1.5 text-sm"
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-xs font-medium text-slate-600" htmlFor="schedule-interval">
+                Интервал, часы
+              </label>
+              <input
+                id="schedule-interval"
+                type="number"
+                min={1}
+                max={168}
+                value={intervalHours}
+                onChange={(e) => setIntervalHours(Number(e.target.value))}
+                className="w-24 rounded-md border border-slate-300 px-3 py-1.5 text-sm"
+              />
+            </div>
+            <button
+              type="submit"
+              disabled={isCreatingSchedule}
+              className="rounded-md bg-slate-900 px-4 py-1.5 text-sm font-medium text-white hover:bg-slate-700 disabled:opacity-50"
+            >
+              {isCreatingSchedule ? 'Создаём…' : 'Добавить расписание'}
+            </button>
+          </div>
+        </form>
+
+        {schedulesQuery.isLoading && <LoadingState />}
+        {schedulesQuery.isError && (
+          <ErrorState message="Не удалось загрузить расписания" onRetry={() => schedulesQuery.refetch()} />
+        )}
+        {schedulesQuery.isSuccess && schedulesQuery.data.length === 0 && (
+          <EmptyState message="Расписаний пока нет" />
+        )}
+
+        {schedulesQuery.isSuccess && schedulesQuery.data.length > 0 && (
+          <div className="overflow-x-auto rounded-lg border border-slate-200 bg-white">
+            <table className="w-full text-left text-sm">
+              <thead className="border-b border-slate-200 bg-slate-50 text-xs uppercase text-slate-500">
+                <tr>
+                  <th className="px-4 py-2">Интервал</th>
+                  <th className="px-4 py-2">Статус</th>
+                  <th className="px-4 py-2">Следующий запуск</th>
+                  <th className="px-4 py-2">Последний запуск</th>
+                  <th className="px-4 py-2" />
+                </tr>
+              </thead>
+              <tbody>
+                {schedulesQuery.data.map((schedule) => (
+                  <tr key={schedule.id} className="border-b border-slate-100 last:border-0">
+                    <td className="px-4 py-2 text-slate-700">каждые {schedule.interval_minutes / 60} ч</td>
+                    <td className="px-4 py-2 text-slate-700">{schedule.enabled ? 'активно' : 'приостановлено'}</td>
+                    <td className="px-4 py-2 text-slate-500">{formatTimestamp(schedule.next_run_at)}</td>
+                    <td className="px-4 py-2 text-slate-500">{formatTimestamp(schedule.last_run_at)}</td>
+                    <td className="px-4 py-2 text-right">
+                      <button
+                        type="button"
+                        disabled={pendingScheduleId === schedule.id}
+                        onClick={() => handleToggleSchedule(schedule.id, schedule.enabled)}
+                        className="rounded-md border border-slate-300 px-2 py-1 text-xs font-medium text-slate-700 hover:bg-slate-100 disabled:opacity-50"
+                      >
+                        {schedule.enabled ? 'Приостановить' : 'Возобновить'}
+                      </button>
+                      <button
+                        type="button"
+                        disabled={pendingScheduleId === schedule.id}
+                        onClick={() => handleDeleteSchedule(schedule.id)}
+                        className="ml-2 rounded-md border border-slate-300 px-2 py-1 text-xs font-medium text-slate-700 hover:bg-slate-100 disabled:opacity-50"
+                      >
+                        Удалить
+                      </button>
                     </td>
                   </tr>
                 ))}

--- a/migrations/versions/d4e5f6a7b8c9_add_scheduled_scrapes.py
+++ b/migrations/versions/d4e5f6a7b8c9_add_scheduled_scrapes.py
@@ -1,0 +1,45 @@
+"""add scheduled_scrapes
+
+Revision ID: d4e5f6a7b8c9
+Revises: c3d4e5f6a7b8
+Create Date: 2026-09-10 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'd4e5f6a7b8c9'
+down_revision: Union[str, Sequence[str], None] = 'c3d4e5f6a7b8'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'scheduled_scrapes',
+        sa.Column('id', sa.Uuid(), nullable=False),
+        sa.Column('source_id', sa.Uuid(), nullable=False),
+        sa.Column('query', sa.JSON(), nullable=True),
+        sa.Column('interval_minutes', sa.Integer(), nullable=False),
+        sa.Column('enabled', sa.Boolean(), nullable=False),
+        sa.Column('next_run_at', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('last_run_at', sa.DateTime(timezone=True), nullable=True),
+        sa.Column('last_job_id', sa.Uuid(), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(['last_job_id'], ['scrape_jobs.id']),
+        sa.ForeignKeyConstraint(['source_id'], ['sources.id']),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index(
+        'ix_scheduled_scrapes_enabled_next_run_at', 'scheduled_scrapes', ['enabled', 'next_run_at']
+    )
+
+
+def downgrade() -> None:
+    op.drop_index('ix_scheduled_scrapes_enabled_next_run_at', table_name='scheduled_scrapes')
+    op.drop_table('scheduled_scrapes')

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -1,0 +1,105 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.db.base import Base
+from app.models.scheduled_scrape import ScheduledScrape
+from app.models.scrape_job import ScrapeJob, ScrapeJobStatus
+from app.models.source import Source
+from app.scraping.scheduler import run_due_scheduled_scrapes
+
+
+@pytest.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:", poolclass=StaticPool, connect_args={"check_same_thread": False}
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    yield factory
+    await engine.dispose()
+
+
+class RecordingRedis:
+    def __init__(self):
+        self.enqueued: list[tuple[str, tuple]] = []
+
+    async def enqueue_job(self, function: str, *args) -> None:
+        self.enqueued.append((function, args))
+
+
+async def _seed_source(factory) -> object:
+    async with factory() as session:
+        source = Source(
+            code="polovniautomobili", name="Polovni Automobili", domain="polovniautomobili.com", country="RS"
+        )
+        session.add(source)
+        await session.commit()
+        return source.id
+
+
+async def _seed_schedule(factory, source_id, next_run_at, enabled=True, interval_minutes=60) -> object:
+    async with factory() as session:
+        schedule = ScheduledScrape(
+            source_id=source_id,
+            query={"search_query": {"make": "Skoda"}, "max_pages": 3},
+            interval_minutes=interval_minutes,
+            enabled=enabled,
+            next_run_at=next_run_at,
+        )
+        session.add(schedule)
+        await session.commit()
+        return schedule.id
+
+
+async def test_creates_and_enqueues_job_for_due_schedule(session_factory):
+    source_id = await _seed_source(session_factory)
+    past = datetime.now(timezone.utc) - timedelta(minutes=1)
+    schedule_id = await _seed_schedule(session_factory, source_id, next_run_at=past)
+    redis = RecordingRedis()
+
+    await run_due_scheduled_scrapes({"session_factory": session_factory, "redis": redis})
+
+    async with session_factory() as session:
+        jobs = (await session.execute(ScrapeJob.__table__.select())).fetchall()
+        assert len(jobs) == 1
+        assert jobs[0].status == ScrapeJobStatus.PENDING
+        assert jobs[0].query == {"search_query": {"make": "Skoda"}, "max_pages": 3}
+
+        schedule = await session.get(ScheduledScrape, schedule_id)
+        assert schedule.last_run_at is not None
+        assert schedule.last_job_id == jobs[0].id
+        # sqlite round-trips DateTime(timezone=True) as naive, so compare the two DB-read values
+        # to each other rather than against the tz-aware `past` computed in this test.
+        assert schedule.next_run_at - schedule.last_run_at >= timedelta(minutes=59)
+
+    assert len(redis.enqueued) == 1
+    assert redis.enqueued[0][0] == "run_scrape_job"
+
+
+async def test_skips_schedule_not_yet_due(session_factory):
+    source_id = await _seed_source(session_factory)
+    future = datetime.now(timezone.utc) + timedelta(hours=1)
+    await _seed_schedule(session_factory, source_id, next_run_at=future)
+    redis = RecordingRedis()
+
+    await run_due_scheduled_scrapes({"session_factory": session_factory, "redis": redis})
+
+    assert redis.enqueued == []
+    async with session_factory() as session:
+        jobs = (await session.execute(ScrapeJob.__table__.select())).fetchall()
+        assert jobs == []
+
+
+async def test_skips_disabled_schedule(session_factory):
+    source_id = await _seed_source(session_factory)
+    past = datetime.now(timezone.utc) - timedelta(minutes=1)
+    await _seed_schedule(session_factory, source_id, next_run_at=past, enabled=False)
+    redis = RecordingRedis()
+
+    await run_due_scheduled_scrapes({"session_factory": session_factory, "redis": redis})
+
+    assert redis.enqueued == []

--- a/tests/unit/test_scrape_endpoints.py
+++ b/tests/unit/test_scrape_endpoints.py
@@ -244,3 +244,90 @@ async def test_list_scrape_jobs_requires_admin(client, email_sender):
     await _register_and_login(client, email_sender)
     response = await client.get("/api/v1/scrape/jobs")
     assert response.status_code == 403
+
+
+async def test_create_scheduled_scrape(client, email_sender, session_factory):
+    await _register_login_and_promote(client, email_sender, session_factory)
+
+    response = await client.post(
+        "/api/v1/scrape/schedules",
+        json={"source_code": "polovniautomobili", "query": {"make": "Skoda"}, "max_pages": 2, "interval_minutes": 60},
+        headers=_csrf_headers(client),
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["interval_minutes"] == 60
+    assert body["enabled"] is True
+    assert body["query"]["search_query"]["make"] == "Skoda"
+    assert body["next_run_at"] is not None
+    assert body["last_run_at"] is None
+
+
+async def test_create_scheduled_scrape_rejects_interval_below_minimum(client, email_sender, session_factory):
+    await _register_login_and_promote(client, email_sender, session_factory)
+
+    response = await client.post(
+        "/api/v1/scrape/schedules",
+        json={"source_code": "polovniautomobili", "interval_minutes": 1},
+        headers=_csrf_headers(client),
+    )
+
+    assert response.status_code == 422
+
+
+async def test_list_scheduled_scrapes(client, email_sender, session_factory):
+    await _register_login_and_promote(client, email_sender, session_factory)
+    await client.post(
+        "/api/v1/scrape/schedules",
+        json={"source_code": "polovniautomobili", "interval_minutes": 60},
+        headers=_csrf_headers(client),
+    )
+
+    response = await client.get("/api/v1/scrape/schedules")
+
+    assert response.status_code == 200
+    assert len(response.json()) == 1
+
+
+async def test_update_scheduled_scrape_toggles_enabled_and_interval(client, email_sender, session_factory):
+    await _register_login_and_promote(client, email_sender, session_factory)
+    create_response = await client.post(
+        "/api/v1/scrape/schedules",
+        json={"source_code": "polovniautomobili", "interval_minutes": 60},
+        headers=_csrf_headers(client),
+    )
+    schedule_id = create_response.json()["id"]
+
+    response = await client.patch(
+        f"/api/v1/scrape/schedules/{schedule_id}",
+        json={"enabled": False, "interval_minutes": 120},
+        headers=_csrf_headers(client),
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["enabled"] is False
+    assert body["interval_minutes"] == 120
+
+
+async def test_delete_scheduled_scrape(client, email_sender, session_factory):
+    await _register_login_and_promote(client, email_sender, session_factory)
+    create_response = await client.post(
+        "/api/v1/scrape/schedules",
+        json={"source_code": "polovniautomobili", "interval_minutes": 60},
+        headers=_csrf_headers(client),
+    )
+    schedule_id = create_response.json()["id"]
+
+    response = await client.delete(f"/api/v1/scrape/schedules/{schedule_id}", headers=_csrf_headers(client))
+    assert response.status_code == 204
+
+    list_response = await client.get("/api/v1/scrape/schedules")
+    assert list_response.json() == []
+
+
+async def test_scheduled_scrapes_require_admin(client, email_sender):
+    await _register_and_login(client, email_sender)
+    response = await client.get("/api/v1/scrape/schedules")
+    assert response.status_code == 403


### PR DESCRIPTION
## Summary
- Adds `ScheduledScrape` (source + query + `interval_minutes`), a standalone admin scheduling tool — kept separate from [issue #26](https://github.com/sityaevDI/car-ad-scraper/issues/26)'s per-user/per-plan saved-search scheduler, which needs a `saved_searches` CRUD layer that doesn't exist yet ([saved_search.py](app/models/saved_search.py) is schema-only). This is a smaller, self-contained way to keep data fresh right now; #26 can build on the same queue infrastructure later.
- An arq cron job (`app/scraping/scheduler.py`) runs every minute inside the existing worker process (`WorkerSettings.cron_jobs`), creates+enqueues a `ScrapeJob` for every due schedule, and advances `next_run_at`.
- Admin API: `GET`/`POST /api/v1/scrape/schedules`, `PATCH` (toggle `enabled`, change `interval_minutes`), `DELETE`. Minimum interval is 5 minutes.
- Minimal UI on `/admin/jobs`: create-schedule form (make, max pages, interval in hours) and a table with pause/resume/delete.

## Test plan
- [x] `pytest` — 121 passed, `ruff check`, `mypy app` — clean
- [x] Frontend `tsc -b`, `oxlint` — clean
- [x] End-to-end against real Postgres/Redis/arq worker: created a schedule via the API with a past `next_run_at`, watched the worker's cron tick pick it up, create and run a `ScrapeJob`, and advance `next_run_at` by the interval; exercised create/pause/resume/delete through the `/admin/jobs` UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)