### PR TITLE
Wire FULL_SOURCE_REFRESH into scrape pipeline, close listing status gap

### DIFF
--- a/app/api/v1/scrape.py
+++ b/app/api/v1/scrape.py
@@ -168,6 +168,9 @@ async def list_scheduled_scrapes(
     return [ScheduledScrapeOut.model_validate(s) for s in schedules]
 
 
+_SCHEDULABLE_JOB_TYPES = {ScrapeJobType.SEARCH, ScrapeJobType.FULL_SOURCE_REFRESH}
+
+
 @router.post("/schedules", response_model=ScheduledScrapeOut, status_code=201)
 async def create_scheduled_scrape(
     payload: ScheduledScrapeCreate,
@@ -179,6 +182,16 @@ async def create_scheduled_scrape(
     if adapter_cls is None:
         raise HTTPException(status_code=400, detail=f"Unknown source_code: {payload.source_code!r}")
 
+    if payload.job_type not in _SCHEDULABLE_JOB_TYPES:
+        raise HTTPException(status_code=400, detail=f"Unsupported job_type for a schedule: {payload.job_type.value!r}")
+
+    if payload.job_type == ScrapeJobType.FULL_SOURCE_REFRESH and payload.query.model_dump(exclude_none=True):
+        # mark_missing_as_removed (app/listings/repository.py) treats "not seen this crawl" as
+        # "removed from the source" — safe only when the crawl actually covers the whole source.
+        raise HTTPException(
+            status_code=400, detail="full_source_refresh schedules must not filter the search query"
+        )
+
     source = await get_or_create_source(
         session,
         code=adapter_cls.source_code,
@@ -188,6 +201,7 @@ async def create_scheduled_scrape(
     )
     schedule = ScheduledScrape(
         source_id=source.id,
+        job_type=payload.job_type,
         query=encode_job_query(payload.query, payload.max_pages),
         interval_minutes=payload.interval_minutes,
         next_run_at=payload.start_at or datetime.now(timezone.utc),

--- a/app/listings/repository.py
+++ b/app/listings/repository.py
@@ -102,10 +102,9 @@ class ListingRepository:
         """Mark active listings for a source that were not encountered in the latest crawl as
         removed. Never deletes rows — see docs/adr/17_AGENT_INSTRUCTIONS.md.
 
-        Only correct for a full-source crawl. Not called from `scraping/pipeline.py` yet, since
-        that pipeline runs one filtered SearchQuery at a time — calling this against a partial
-        result set would wrongly mark every listing outside that filter as removed. Wire it up
-        once a FULL_SOURCE_REFRESH job type is actually implemented.
+        Only correct for a full-source crawl — called from `run_scrape` (app/scraping/pipeline.py)
+        for FULL_SOURCE_REFRESH jobs only, since a filtered SearchQuery would make every listing
+        outside that filter look "missing" and get wrongly marked removed.
         """
         result = await self.session.execute(
             select(Listing).where(Listing.source_id == source_id, Listing.status == ListingStatus.ACTIVE)

--- a/app/models/scheduled_scrape.py
+++ b/app/models/scheduled_scrape.py
@@ -1,11 +1,12 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import JSON, Boolean, DateTime, ForeignKey, Integer, Uuid
+from sqlalchemy import JSON, Boolean, DateTime, Enum, ForeignKey, Integer, Uuid
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.db.base import Base
 from app.models.mixins import TimestampMixin, UUIDPkMixin
+from app.models.scrape_job import ScrapeJobType
 
 # A standalone admin-defined "run this query every N minutes" schedule — deliberately not tied to
 # SavedSearch/subscription plans (see docs/adr/20_ROLES_AND_ADMIN.md and issue #26, which is the
@@ -16,6 +17,9 @@ class ScheduledScrape(UUIDPkMixin, TimestampMixin, Base):
     __tablename__ = "scheduled_scrapes"
 
     source_id: Mapped[uuid.UUID] = mapped_column(Uuid, ForeignKey("sources.id"), nullable=False)
+    job_type: Mapped[ScrapeJobType] = mapped_column(
+        Enum(ScrapeJobType, native_enum=False, length=32), default=ScrapeJobType.SEARCH, nullable=False
+    )
     query: Mapped[dict | None] = mapped_column(JSON, nullable=True)
     interval_minutes: Mapped[int] = mapped_column(Integer, nullable=False)
     enabled: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)

--- a/app/scraping/pipeline.py
+++ b/app/scraping/pipeline.py
@@ -22,8 +22,10 @@ class ScrapeStats:
     listings_seen: int = 0
     listings_created: int = 0
     listings_updated: int = 0
+    listings_removed: int = 0
     outcome_counts: dict[str, int] = field(default_factory=dict)
     blocked: bool = False
+    seen_external_ids: set[str] = field(default_factory=set)
 
 
 async def get_or_create_source(session: AsyncSession, code: str, name: str, domain: str, country: str) -> Source:
@@ -57,7 +59,15 @@ async def run_scrape(
     query: SearchQuery,
     max_pages: int = 5,
     proxy_provider: ProxyProvider | None = None,
+    mark_removed: bool = False,
 ) -> ScrapeStats:
+    """`mark_removed` transitions listings absent from this crawl to REMOVED (see
+    ListingRepository.mark_missing_as_removed) — only safe when `query` covers the whole source,
+    since anything filtered out would otherwise look "missing" and get marked removed too. Callers
+    only pass it for FULL_SOURCE_REFRESH jobs (see app/scraping/worker.py), and it's skipped here
+    whenever the crawl was cut short by FetchBlockedError, since a partial crawl can't tell a
+    genuinely removed listing from one it just didn't get to yet.
+    """
     counter = OutcomeCounter()
     adapter = get_source_adapter(
         source_code, max_pages=max_pages, proxy_provider=proxy_provider, outcome_sink=counter.record
@@ -71,6 +81,7 @@ async def run_scrape(
     try:
         async for source_listing in _search_listings(adapter, query):
             stats.listings_seen += 1
+            stats.seen_external_ids.add(source_listing.external_id)
             _, is_new = await repository.upsert_listing(source.id, source_listing)
             if is_new:
                 stats.listings_created += 1
@@ -81,6 +92,9 @@ async def run_scrape(
         # result is more useful than losing it, and burning further proxy/direct requests against
         # a source that just told us to back off would be wasteful.
         stats.blocked = True
+
+    if mark_removed and not stats.blocked and stats.listings_seen > 0:
+        stats.listings_removed = await repository.mark_missing_as_removed(source.id, stats.seen_external_ids)
 
     stats.outcome_counts = counter.as_dict()
     await session.commit()

--- a/app/scraping/scheduler.py
+++ b/app/scraping/scheduler.py
@@ -9,7 +9,7 @@ from typing import Any
 from sqlalchemy import select
 
 from app.models.scheduled_scrape import ScheduledScrape
-from app.models.scrape_job import ScrapeJob, ScrapeJobStatus, ScrapeJobType
+from app.models.scrape_job import ScrapeJob, ScrapeJobStatus
 
 
 async def run_due_scheduled_scrapes(ctx: dict[str, Any]) -> None:
@@ -23,7 +23,7 @@ async def run_due_scheduled_scrapes(ctx: dict[str, Any]) -> None:
         for scheduled in due:
             job = ScrapeJob(
                 source_id=scheduled.source_id,
-                job_type=ScrapeJobType.SEARCH,
+                job_type=scheduled.job_type,
                 status=ScrapeJobStatus.PENDING,
                 query=scheduled.query,
             )

--- a/app/scraping/schemas.py
+++ b/app/scraping/schemas.py
@@ -46,6 +46,7 @@ class ScrapeJobOut(BaseModel):
 
 class ScheduledScrapeCreate(BaseModel):
     source_code: str
+    job_type: ScrapeJobType = ScrapeJobType.SEARCH
     query: SearchQuery = Field(default_factory=SearchQuery)
     max_pages: int = 5
     interval_minutes: int = Field(ge=5)
@@ -62,6 +63,7 @@ class ScheduledScrapeOut(BaseModel):
 
     id: uuid.UUID
     source_id: uuid.UUID
+    job_type: ScrapeJobType
     query: dict | None
     interval_minutes: int
     enabled: bool

--- a/app/scraping/worker.py
+++ b/app/scraping/worker.py
@@ -14,7 +14,7 @@ from arq.connections import RedisSettings
 
 from app.config import get_settings
 from app.db.session import get_session_factory
-from app.models.scrape_job import ScrapeJob, ScrapeJobStatus
+from app.models.scrape_job import ScrapeJob, ScrapeJobStatus, ScrapeJobType
 from app.models.source import Source
 from app.scraping.pipeline import run_scrape
 from app.scraping.proxy import get_proxy_provider
@@ -51,6 +51,7 @@ async def run_scrape_job(ctx: dict[str, Any], job_id: str) -> None:
                 query=query,
                 max_pages=max_pages,
                 proxy_provider=ctx["proxy_provider"],
+                mark_removed=job.job_type == ScrapeJobType.FULL_SOURCE_REFRESH,
             )
         except Exception as exc:  # noqa: BLE001 - persisted below, not swallowed silently
             job.status = ScrapeJobStatus.FAILED
@@ -64,6 +65,7 @@ async def run_scrape_job(ctx: dict[str, Any], job_id: str) -> None:
             "listings_seen": stats.listings_seen,
             "listings_created": stats.listings_created,
             "listings_updated": stats.listings_updated,
+            "listings_removed": stats.listings_removed,
             "outcome_counts": stats.outcome_counts,
         }
         job.finished_at = datetime.now(timezone.utc)

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -77,11 +77,18 @@ export const scrapeApi = {
 
   listSchedules: () => apiFetch<ScheduledScrapeOut[]>('/api/v1/scrape/schedules'),
 
-  createSchedule: (sourceCode: string, intervalMinutes: number, make?: string, maxPages = 5) =>
+  createSchedule: (
+    sourceCode: string,
+    intervalMinutes: number,
+    make?: string,
+    maxPages = 5,
+    jobType: ScrapeJobType = 'search',
+  ) =>
     apiFetch<ScheduledScrapeOut>('/api/v1/scrape/schedules', {
       method: 'POST',
       body: JSON.stringify({
         source_code: sourceCode,
+        job_type: jobType,
         query: make ? { make } : {},
         max_pages: maxPages,
         interval_minutes: intervalMinutes,
@@ -100,6 +107,7 @@ export const scrapeApi = {
 export interface ScheduledScrapeOut {
   id: string
   source_id: string
+  job_type: ScrapeJobType
   query: Record<string, unknown> | null
   interval_minutes: number
   enabled: boolean

--- a/frontend/src/pages/AdminJobsPage.tsx
+++ b/frontend/src/pages/AdminJobsPage.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { EmptyState, ErrorState, LoadingState } from '../components/StateMessage'
-import { ApiError, type ScrapeJobStatus, scrapeApi } from '../lib/api'
+import { ApiError, type ScrapeJobStatus, type ScrapeJobType, scrapeApi } from '../lib/api'
 
 const STATUS_OPTIONS: { value: ScrapeJobStatus | ''; label: string }[] = [
   { value: '', label: 'Все статусы' },
@@ -12,6 +12,27 @@ const STATUS_OPTIONS: { value: ScrapeJobStatus | ''; label: string }[] = [
   { value: 'failed', label: 'Ошибка' },
   { value: 'cancelled', label: 'Отменено' },
 ]
+
+// Only types the pipeline actually gives distinct behavior to are offered here — the rest
+// (listing_refresh, saved_search_refresh, market_refresh) are declared on the backend for later
+// phases but aren't wired into run_scrape yet, so scheduling them would silently behave like a
+// plain search.
+const SCHEDULABLE_JOB_TYPES: { value: ScrapeJobType; label: string; hint: string }[] = [
+  { value: 'search', label: 'Поиск по фильтру', hint: 'Обновляет объявления, попадающие под фильтр ниже.' },
+  {
+    value: 'full_source_refresh',
+    label: 'Полное обновление источника',
+    hint: 'Обходит источник целиком (без фильтра) и помечает пропавшие объявления как REMOVED.',
+  },
+]
+
+const JOB_TYPE_LABELS: Record<ScrapeJobType, string> = {
+  search: 'Поиск по фильтру',
+  full_source_refresh: 'Полное обновление источника',
+  listing_refresh: 'Обновление объявления',
+  saved_search_refresh: 'Обновление сохранённого поиска',
+  market_refresh: 'Обновление рынка',
+}
 
 const RETRYABLE = new Set<ScrapeJobStatus>(['failed', 'cancelled'])
 const CANCELLABLE = new Set<ScrapeJobStatus>(['pending', 'running'])
@@ -29,6 +50,7 @@ export function AdminJobsPage() {
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [pendingActionId, setPendingActionId] = useState<string | null>(null)
 
+  const [scheduleJobType, setScheduleJobType] = useState<ScrapeJobType>('search')
   const [scheduleMake, setScheduleMake] = useState('')
   const [scheduleMaxPages, setScheduleMaxPages] = useState(5)
   const [intervalHours, setIntervalHours] = useState(6)
@@ -86,7 +108,14 @@ export function AdminJobsPage() {
     setScheduleFormError(null)
     setIsCreatingSchedule(true)
     try {
-      await scrapeApi.createSchedule('polovniautomobili', intervalHours * 60, scheduleMake || undefined, scheduleMaxPages)
+      const isFullSourceRefresh = scheduleJobType === 'full_source_refresh'
+      await scrapeApi.createSchedule(
+        'polovniautomobili',
+        intervalHours * 60,
+        isFullSourceRefresh ? undefined : scheduleMake || undefined,
+        scheduleMaxPages,
+        scheduleJobType,
+      )
       setScheduleMake('')
       await schedulesQuery.refetch()
     } catch (err) {
@@ -212,7 +241,7 @@ export function AdminJobsPage() {
               <tbody>
                 {jobsQuery.data.map((job) => (
                   <tr key={job.id} className="border-b border-slate-100 last:border-0">
-                    <td className="px-4 py-2 text-slate-700">{job.job_type}</td>
+                    <td className="px-4 py-2 text-slate-700">{JOB_TYPE_LABELS[job.job_type]}</td>
                     <td className="px-4 py-2 text-slate-700">{job.status}</td>
                     <td className="px-4 py-2 text-slate-500">{formatTimestamp(job.started_at)}</td>
                     <td className="px-4 py-2 text-slate-500">{formatTimestamp(job.finished_at)}</td>
@@ -259,6 +288,23 @@ export function AdminJobsPage() {
           {scheduleFormError && <p className="mb-3 text-sm text-red-600">{scheduleFormError}</p>}
           <div className="flex flex-wrap items-end gap-3">
             <div>
+              <label className="mb-1 block text-xs font-medium text-slate-600" htmlFor="schedule-job-type">
+                Тип задачи
+              </label>
+              <select
+                id="schedule-job-type"
+                value={scheduleJobType}
+                onChange={(e) => setScheduleJobType(e.target.value as ScrapeJobType)}
+                className="rounded-md border border-slate-300 px-3 py-1.5 text-sm"
+              >
+                {SCHEDULABLE_JOB_TYPES.map((opt) => (
+                  <option key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div>
               <label className="mb-1 block text-xs font-medium text-slate-600" htmlFor="schedule-make">
                 Марка (опционально)
               </label>
@@ -267,7 +313,8 @@ export function AdminJobsPage() {
                 value={scheduleMake}
                 onChange={(e) => setScheduleMake(e.target.value)}
                 placeholder="Skoda"
-                className="rounded-md border border-slate-300 px-3 py-1.5 text-sm"
+                disabled={scheduleJobType === 'full_source_refresh'}
+                className="rounded-md border border-slate-300 px-3 py-1.5 text-sm disabled:bg-slate-50 disabled:text-slate-400"
               />
             </div>
             <div>
@@ -306,6 +353,9 @@ export function AdminJobsPage() {
               {isCreatingSchedule ? 'Создаём…' : 'Добавить расписание'}
             </button>
           </div>
+          <p className="mt-2 text-xs text-slate-500">
+            {SCHEDULABLE_JOB_TYPES.find((opt) => opt.value === scheduleJobType)?.hint}
+          </p>
         </form>
 
         {schedulesQuery.isLoading && <LoadingState />}
@@ -321,6 +371,7 @@ export function AdminJobsPage() {
             <table className="w-full text-left text-sm">
               <thead className="border-b border-slate-200 bg-slate-50 text-xs uppercase text-slate-500">
                 <tr>
+                  <th className="px-4 py-2">Тип</th>
                   <th className="px-4 py-2">Интервал</th>
                   <th className="px-4 py-2">Статус</th>
                   <th className="px-4 py-2">Следующий запуск</th>
@@ -331,6 +382,7 @@ export function AdminJobsPage() {
               <tbody>
                 {schedulesQuery.data.map((schedule) => (
                   <tr key={schedule.id} className="border-b border-slate-100 last:border-0">
+                    <td className="px-4 py-2 text-slate-700">{JOB_TYPE_LABELS[schedule.job_type]}</td>
                     <td className="px-4 py-2 text-slate-700">каждые {schedule.interval_minutes / 60} ч</td>
                     <td className="px-4 py-2 text-slate-700">{schedule.enabled ? 'активно' : 'приостановлено'}</td>
                     <td className="px-4 py-2 text-slate-500">{formatTimestamp(schedule.next_run_at)}</td>

--- a/migrations/versions/e5f6a7b8c9d0_add_scheduled_scrape_job_type.py
+++ b/migrations/versions/e5f6a7b8c9d0_add_scheduled_scrape_job_type.py
@@ -1,0 +1,39 @@
+"""add job_type to scheduled_scrapes
+
+Revision ID: e5f6a7b8c9d0
+Revises: d4e5f6a7b8c9
+Create Date: 2026-09-09 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'e5f6a7b8c9d0'
+down_revision: Union[str, Sequence[str], None] = 'd4e5f6a7b8c9'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'scheduled_scrapes',
+        sa.Column(
+            'job_type',
+            sa.Enum(
+                'SEARCH', 'LISTING_REFRESH', 'SAVED_SEARCH_REFRESH', 'FULL_SOURCE_REFRESH', 'MARKET_REFRESH',
+                name='scrapejobtype', native_enum=False, length=32,
+            ),
+            nullable=False,
+            server_default='SEARCH',
+        ),
+    )
+    with op.batch_alter_table('scheduled_scrapes') as batch_op:
+        batch_op.alter_column('job_type', server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_column('scheduled_scrapes', 'job_type')

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -3,7 +3,7 @@ from collections.abc import AsyncIterator
 from sqlalchemy import select
 
 import app.sources.registry as registry
-from app.models.listing import Listing
+from app.models.listing import Listing, ListingStatus
 from app.scraping.fetch_outcome import FetchBlockedError, FetchOutcome
 from app.scraping.pipeline import run_scrape
 from app.search.query import SearchQuery
@@ -22,6 +22,26 @@ def _listing(external_id: str, price: int) -> SourceListing:
         price=price,
         currency="EUR",
     )
+
+
+class StubAdapter:
+    source_code = "stub_source"
+    display_name = "Stub Source"
+    domain = "stub.example.com"
+    country = "RS"
+
+    def __init__(self, max_pages=5, proxy_provider=None, outcome_sink=None):
+        self.outcome_sink = outcome_sink
+
+    async def search_with_data(self, query: SearchQuery) -> AsyncIterator[SourceListing]:
+        for external_id in self.external_ids:
+            if self.outcome_sink:
+                self.outcome_sink(FetchOutcome.SUCCESS)
+            yield _listing(external_id, 10_000)
+
+
+def _make_stub_adapter(external_ids: list[str]) -> type[StubAdapter]:
+    return type("_ConfiguredStubAdapter", (StubAdapter,), {"external_ids": external_ids})
 
 
 class StubBlockedAdapter:
@@ -56,3 +76,41 @@ async def test_run_scrape_persists_partial_results_when_blocked_mid_crawl(sessio
 
     persisted = (await session.execute(select(Listing))).scalars().all()
     assert len(persisted) == 2
+
+
+async def test_run_scrape_marks_missing_listings_removed_when_mark_removed_is_true(session, monkeypatch):
+    monkeypatch.setitem(registry.SOURCE_REGISTRY, "stub_source", _make_stub_adapter(["1", "2", "3"]))
+    await run_scrape(session, source_code="stub_source", query=SearchQuery(), mark_removed=True)
+
+    monkeypatch.setitem(registry.SOURCE_REGISTRY, "stub_source", _make_stub_adapter(["1", "2"]))
+    stats = await run_scrape(session, source_code="stub_source", query=SearchQuery(), mark_removed=True)
+
+    assert stats.listings_removed == 1
+    rows = (await session.execute(select(Listing))).scalars().all()
+    persisted = {listing.external_id: listing.status for listing in rows}
+    assert persisted == {"1": ListingStatus.ACTIVE, "2": ListingStatus.ACTIVE, "3": ListingStatus.REMOVED}
+
+
+async def test_run_scrape_does_not_mark_removed_by_default(session, monkeypatch):
+    monkeypatch.setitem(registry.SOURCE_REGISTRY, "stub_source", _make_stub_adapter(["1", "2", "3"]))
+    await run_scrape(session, source_code="stub_source", query=SearchQuery())
+
+    monkeypatch.setitem(registry.SOURCE_REGISTRY, "stub_source", _make_stub_adapter(["1"]))
+    stats = await run_scrape(session, source_code="stub_source", query=SearchQuery())
+
+    assert stats.listings_removed == 0
+    statuses = {listing.status for listing in (await session.execute(select(Listing))).scalars().all()}
+    assert statuses == {ListingStatus.ACTIVE}
+
+
+async def test_run_scrape_skips_mark_removed_when_blocked_mid_crawl(session, monkeypatch):
+    monkeypatch.setitem(registry.SOURCE_REGISTRY, "stub_source", _make_stub_adapter(["1", "2", "3"]))
+    await run_scrape(session, source_code="stub_source", query=SearchQuery(), mark_removed=True)
+
+    monkeypatch.setitem(registry.SOURCE_REGISTRY, "stub_source", StubBlockedAdapter)
+    stats = await run_scrape(session, source_code="stub_source", query=SearchQuery(), max_pages=1, mark_removed=True)
+
+    assert stats.blocked is True
+    assert stats.listings_removed == 0
+    statuses = {listing.status for listing in (await session.execute(select(Listing))).scalars().all()}
+    assert statuses == {ListingStatus.ACTIVE}

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -6,7 +6,7 @@ from sqlalchemy.pool import StaticPool
 
 from app.db.base import Base
 from app.models.scheduled_scrape import ScheduledScrape
-from app.models.scrape_job import ScrapeJob, ScrapeJobStatus
+from app.models.scrape_job import ScrapeJob, ScrapeJobStatus, ScrapeJobType
 from app.models.source import Source
 from app.scraping.scheduler import run_due_scheduled_scrapes
 
@@ -41,11 +41,20 @@ async def _seed_source(factory) -> object:
         return source.id
 
 
-async def _seed_schedule(factory, source_id, next_run_at, enabled=True, interval_minutes=60) -> object:
+async def _seed_schedule(
+    factory,
+    source_id,
+    next_run_at,
+    enabled=True,
+    interval_minutes=60,
+    job_type=ScrapeJobType.SEARCH,
+    query=None,
+) -> object:
     async with factory() as session:
         schedule = ScheduledScrape(
             source_id=source_id,
-            query={"search_query": {"make": "Skoda"}, "max_pages": 3},
+            job_type=job_type,
+            query=query if query is not None else {"search_query": {"make": "Skoda"}, "max_pages": 3},
             interval_minutes=interval_minutes,
             enabled=enabled,
             next_run_at=next_run_at,
@@ -67,6 +76,7 @@ async def test_creates_and_enqueues_job_for_due_schedule(session_factory):
         jobs = (await session.execute(ScrapeJob.__table__.select())).fetchall()
         assert len(jobs) == 1
         assert jobs[0].status == ScrapeJobStatus.PENDING
+        assert jobs[0].job_type == ScrapeJobType.SEARCH
         assert jobs[0].query == {"search_query": {"make": "Skoda"}, "max_pages": 3}
 
         schedule = await session.get(ScheduledScrape, schedule_id)
@@ -92,6 +102,22 @@ async def test_skips_schedule_not_yet_due(session_factory):
     async with session_factory() as session:
         jobs = (await session.execute(ScrapeJob.__table__.select())).fetchall()
         assert jobs == []
+
+
+async def test_creates_job_with_schedules_job_type(session_factory):
+    source_id = await _seed_source(session_factory)
+    past = datetime.now(timezone.utc) - timedelta(minutes=1)
+    await _seed_schedule(
+        session_factory, source_id, next_run_at=past, job_type=ScrapeJobType.FULL_SOURCE_REFRESH, query={}
+    )
+    redis = RecordingRedis()
+
+    await run_due_scheduled_scrapes({"session_factory": session_factory, "redis": redis})
+
+    async with session_factory() as session:
+        jobs = (await session.execute(ScrapeJob.__table__.select())).fetchall()
+        assert len(jobs) == 1
+        assert jobs[0].job_type == ScrapeJobType.FULL_SOURCE_REFRESH
 
 
 async def test_skips_disabled_schedule(session_factory):

--- a/tests/unit/test_scrape_endpoints.py
+++ b/tests/unit/test_scrape_endpoints.py
@@ -257,11 +257,56 @@ async def test_create_scheduled_scrape(client, email_sender, session_factory):
 
     assert response.status_code == 201
     body = response.json()
+    assert body["job_type"] == "search"
     assert body["interval_minutes"] == 60
     assert body["enabled"] is True
     assert body["query"]["search_query"]["make"] == "Skoda"
     assert body["next_run_at"] is not None
     assert body["last_run_at"] is None
+
+
+async def test_create_scheduled_scrape_accepts_full_source_refresh_with_empty_query(
+    client, email_sender, session_factory
+):
+    await _register_login_and_promote(client, email_sender, session_factory)
+
+    response = await client.post(
+        "/api/v1/scrape/schedules",
+        json={"source_code": "polovniautomobili", "job_type": "full_source_refresh", "interval_minutes": 60},
+        headers=_csrf_headers(client),
+    )
+
+    assert response.status_code == 201
+    assert response.json()["job_type"] == "full_source_refresh"
+
+
+async def test_create_scheduled_scrape_rejects_filtered_full_source_refresh(client, email_sender, session_factory):
+    await _register_login_and_promote(client, email_sender, session_factory)
+
+    response = await client.post(
+        "/api/v1/scrape/schedules",
+        json={
+            "source_code": "polovniautomobili",
+            "job_type": "full_source_refresh",
+            "query": {"make": "Skoda"},
+            "interval_minutes": 60,
+        },
+        headers=_csrf_headers(client),
+    )
+
+    assert response.status_code == 400
+
+
+async def test_create_scheduled_scrape_rejects_unimplemented_job_type(client, email_sender, session_factory):
+    await _register_login_and_promote(client, email_sender, session_factory)
+
+    response = await client.post(
+        "/api/v1/scrape/schedules",
+        json={"source_code": "polovniautomobili", "job_type": "listing_refresh", "interval_minutes": 60},
+        headers=_csrf_headers(client),
+    )
+
+    assert response.status_code == 400
 
 
 async def test_create_scheduled_scrape_rejects_interval_below_minimum(client, email_sender, session_factory):

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -1,6 +1,7 @@
 import uuid
 
 import pytest
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlalchemy.pool import StaticPool
 
@@ -30,15 +31,22 @@ async def worker_session_factory():
 
 
 async def _seed_job(
-    factory, status: ScrapeJobStatus = ScrapeJobStatus.PENDING, query: dict | None = None
+    factory,
+    status: ScrapeJobStatus = ScrapeJobStatus.PENDING,
+    query: dict | None = None,
+    job_type: ScrapeJobType = ScrapeJobType.SEARCH,
 ) -> uuid.UUID:
     async with factory() as session:
-        source = Source(
-            code="polovniautomobili", name="Polovni Automobili", domain="polovniautomobili.com", country="RS"
-        )
-        session.add(source)
-        await session.flush()
-        job = ScrapeJob(source_id=source.id, job_type=ScrapeJobType.SEARCH, status=status, query=query or {})
+        source = (
+            await session.execute(select(Source).where(Source.code == "polovniautomobili"))
+        ).scalar_one_or_none()
+        if source is None:
+            source = Source(
+                code="polovniautomobili", name="Polovni Automobili", domain="polovniautomobili.com", country="RS"
+            )
+            session.add(source)
+            await session.flush()
+        job = ScrapeJob(source_id=source.id, job_type=job_type, status=status, query=query or {})
         session.add(job)
         await session.commit()
         return job.id
@@ -47,7 +55,7 @@ async def _seed_job(
 async def test_run_scrape_job_marks_completed_on_success(worker_session_factory, monkeypatch):
     job_id = await _seed_job(worker_session_factory)
 
-    async def fake_run_scrape(session, source_code, query, max_pages=5, proxy_provider=None):
+    async def fake_run_scrape(session, source_code, query, max_pages=5, proxy_provider=None, mark_removed=False):
         return ScrapeStats(listings_seen=3, listings_created=2, listings_updated=1, outcome_counts={"success": 3})
 
     monkeypatch.setattr(worker_module, "run_scrape", fake_run_scrape)
@@ -62,6 +70,7 @@ async def test_run_scrape_job_marks_completed_on_success(worker_session_factory,
             "listings_seen": 3,
             "listings_created": 2,
             "listings_updated": 1,
+            "listings_removed": 0,
             "outcome_counts": {"success": 3},
         }
         assert job.started_at is not None
@@ -71,7 +80,7 @@ async def test_run_scrape_job_marks_completed_on_success(worker_session_factory,
 async def test_run_scrape_job_marks_partial_when_blocked(worker_session_factory, monkeypatch):
     job_id = await _seed_job(worker_session_factory)
 
-    async def fake_run_scrape(session, source_code, query, max_pages=5, proxy_provider=None):
+    async def fake_run_scrape(session, source_code, query, max_pages=5, proxy_provider=None, mark_removed=False):
         return ScrapeStats(listings_seen=1, listings_created=1, blocked=True, outcome_counts={"forbidden": 1})
 
     monkeypatch.setattr(worker_module, "run_scrape", fake_run_scrape)
@@ -87,7 +96,7 @@ async def test_run_scrape_job_marks_partial_when_blocked(worker_session_factory,
 async def test_run_scrape_job_marks_failed_on_exception(worker_session_factory, monkeypatch):
     job_id = await _seed_job(worker_session_factory)
 
-    async def fake_run_scrape(session, source_code, query, max_pages=5, proxy_provider=None):
+    async def fake_run_scrape(session, source_code, query, max_pages=5, proxy_provider=None, mark_removed=False):
         raise RuntimeError("boom")
 
     monkeypatch.setattr(worker_module, "run_scrape", fake_run_scrape)
@@ -106,7 +115,7 @@ async def test_run_scrape_job_passes_stored_query_and_max_pages_to_run_scrape(wo
     job_id = await _seed_job(worker_session_factory, query=encode_job_query(SearchQuery(make="Audi"), max_pages=2))
     received = {}
 
-    async def fake_run_scrape(session, source_code, query, max_pages=5, proxy_provider=None):
+    async def fake_run_scrape(session, source_code, query, max_pages=5, proxy_provider=None, mark_removed=False):
         received["source_code"] = source_code
         received["query"] = query
         received["max_pages"] = max_pages
@@ -120,6 +129,26 @@ async def test_run_scrape_job_passes_stored_query_and_max_pages_to_run_scrape(wo
     assert received["source_code"] == "polovniautomobili"
     assert received["query"].make == "Audi"
     assert received["max_pages"] == 2
+
+
+async def test_run_scrape_job_requests_mark_removed_only_for_full_source_refresh(worker_session_factory, monkeypatch):
+    search_job_id = await _seed_job(worker_session_factory, job_type=ScrapeJobType.SEARCH)
+    full_refresh_job_id = await _seed_job(worker_session_factory, job_type=ScrapeJobType.FULL_SOURCE_REFRESH)
+
+    async def fake_run_scrape(session, source_code, query, max_pages=5, proxy_provider=None, mark_removed=False):
+        return ScrapeStats(listings_removed=2 if mark_removed else 0)
+
+    monkeypatch.setattr(worker_module, "run_scrape", fake_run_scrape)
+    ctx = {"session_factory": worker_session_factory, "proxy_provider": NullProxyProvider()}
+
+    await worker_module.run_scrape_job(ctx, str(search_job_id))
+    await worker_module.run_scrape_job(ctx, str(full_refresh_job_id))
+
+    async with worker_session_factory() as session:
+        search_job = await session.get(ScrapeJob, search_job_id)
+        full_refresh_job = await session.get(ScrapeJob, full_refresh_job_id)
+        assert search_job.stats["listings_removed"] == 0
+        assert full_refresh_job.stats["listings_removed"] == 2
 
 
 async def test_run_scrape_job_skips_already_cancelled_job(worker_session_factory, monkeypatch):


### PR DESCRIPTION
## Summary

Closes #15.

- `mark_missing_as_removed` (app/listings/repository.py) existed but was never called — every scrape job ran as an implicit SEARCH, so `Listing.status` never transitioned to `REMOVED` in practice.
- `run_scrape` (app/scraping/pipeline.py) now tracks `seen_external_ids` during a crawl and accepts `mark_removed`; the worker enables it only for `FULL_SOURCE_REFRESH` jobs, and it's skipped whenever the crawl was cut short (`blocked=True`), since a partial crawl can't tell "genuinely removed" from "just not gotten to yet".
- `ScheduledScrape` gained a `job_type` column (migration `e5f6a7b8c9d0`, default `SEARCH`) so admins can schedule a full-source refresh instead of always scheduling a filtered search.
- The API rejects a `full_source_refresh` schedule with a non-empty query — `mark_missing_as_removed` only makes sense against a crawl that actually covers the whole source; a filtered crawl would wrongly mark everything outside the filter as removed.
- `/admin/jobs` now has a job type selector on the schedule form (only `search` and `full_source_refresh` are offered, since the other declared job types aren't wired into the pipeline yet); picking `full_source_refresh` disables the make filter client-side too.

`ScheduledScrape` stays deliberately separate from `SavedSearch`/subscriptions (see its docstring referencing #26) — this doesn't touch or constrain the future saved-search subscription work.

## Test plan
- [x] `pytest` — 129 passed (new coverage: `run_scrape` mark_removed on/off/blocked, worker dispatch by job_type, scheduler propagates job_type, API validation for filtered/unsupported job types)
- [x] `ruff check` / `mypy app` clean
- [x] Migration verified against a real local Postgres: upgrade → inspect schema → downgrade → upgrade again, all clean
- [x] Manually verified in browser: registered an admin user, created a `full_source_refresh` schedule (make field disabled, query persisted empty), confirmed API rejects a filtered `full_source_refresh` (400) and unsupported job types like `listing_refresh` (400)

🤖 Generated with [Claude Code](https://claude.com/claude-code)