### PR TITLE
Retry network_error via proxy once, log exception detail

### DIFF
--- a/app/scraping/fetch_outcome.py
+++ b/app/scraping/fetch_outcome.py
@@ -76,10 +76,16 @@ def classify_response(response: requests.Response) -> FetchOutcome:
     return FetchOutcome.FORBIDDEN
 
 
-def classify_exception(exc: Exception) -> FetchOutcome:
+def classify_exception(exc: Exception) -> tuple[FetchOutcome, str]:
+    """Returns the outcome alongside `f"{type}: {message}"` — a bare NETWORK_ERROR doesn't say
+    whether it was DNS failure, connection refused, connection reset, or a TLS error, and that
+    distinction matters when reading logs for a source that's silently dropping connections
+    instead of returning a proper 403/429.
+    """
+    detail = f"{type(exc).__name__}: {exc}"
     if isinstance(exc, requests.Timeout):
-        return FetchOutcome.TIMEOUT
-    return FetchOutcome.NETWORK_ERROR
+        return FetchOutcome.TIMEOUT, detail
+    return FetchOutcome.NETWORK_ERROR, detail
 
 
 class OutcomeCounter:

--- a/app/scraping/fetch_strategy.py
+++ b/app/scraping/fetch_strategy.py
@@ -28,6 +28,9 @@ class FetchResult:
     outcome: FetchOutcome
     text: str | None = None
     status_code: int | None = None
+    # Only set for exception-classified outcomes (TIMEOUT/NETWORK_ERROR) — a response-classified
+    # outcome already has status_code/text to explain itself.
+    detail: str | None = None
 
 
 class FetchStrategy(Protocol):
@@ -36,18 +39,19 @@ class FetchStrategy(Protocol):
 
 def _http_request(
     session: requests.Session, url: str, timeout: int, proxy_url: str | None
-) -> tuple[FetchOutcome, requests.Response | None]:
+) -> tuple[FetchOutcome, requests.Response | None, str | None]:
     proxies = {"http": proxy_url, "https": proxy_url} if proxy_url else None
     try:
         response = session.get(url, timeout=timeout, headers=default_request_headers(), proxies=proxies)
     except Exception as exc:  # noqa: BLE001 - classified below, not swallowed
-        return classify_exception(exc), None
-    return classify_response(response), response
+        outcome, detail = classify_exception(exc)
+        return outcome, None, detail
+    return classify_response(response), response, None
 
 
-def _to_result(outcome: FetchOutcome, response: requests.Response | None) -> FetchResult:
+def _to_result(outcome: FetchOutcome, response: requests.Response | None, detail: str | None = None) -> FetchResult:
     if response is None:
-        return FetchResult(outcome=outcome)
+        return FetchResult(outcome=outcome, detail=detail)
     return FetchResult(outcome=outcome, text=response.text, status_code=response.status_code)
 
 
@@ -62,21 +66,26 @@ class HttpFetcher:
         self._outcome_sink = outcome_sink
 
     async def fetch(self, url: str) -> FetchResult:
-        outcome, response = await asyncio.to_thread(_http_request, self.session, url, self.timeout, None)
+        outcome, response, detail = await asyncio.to_thread(_http_request, self.session, url, self.timeout, None)
         if self._outcome_sink is not None:
             self._outcome_sink(outcome)
-        return _to_result(outcome, response)
+        return _to_result(outcome, response, detail)
 
 
 class ProxyHttpFetcher:
-    """Direct-first, proxy-fallback-only-when-blocked (docs/adr/05_ANTI_BOT_PROXY.md §2-4). A
-    proxy attempt is only made when the direct attempt looks block-like (403/429/challenge/
-    captcha) — a timeout or 5xx won't be fixed by a proxy, and every proxied request burns the
-    account's limited residential-proxy quota, so those outcomes are returned immediately instead.
+    """Direct-first, proxy-fallback-only-when-worth-it (docs/adr/05_ANTI_BOT_PROXY.md §2-4). A
+    proxy attempt is made when the direct attempt looks block-like (403/429/challenge/captcha) or
+    came back as NETWORK_ERROR — a connection refused/reset instead of a proper 403 is itself a
+    plausible sign of an IP-level block, so it's worth the one retry. TIMEOUT and SERVER_ERROR are
+    NOT retried through the proxy: those point at the origin being slow/down, which a different
+    egress IP won't fix, and every proxied request burns the account's limited residential-proxy
+    quota.
 
     Ported out of what used to be `PolovniAutomobiliSource._fetch()` so any source adapter can
     reuse the same direct/proxy decision without reimplementing it.
     """
+
+    _PROXY_ELIGIBLE = BLOCK_LIKE | {FetchOutcome.NETWORK_ERROR}
 
     def __init__(
         self,
@@ -96,16 +105,16 @@ class ProxyHttpFetcher:
             self._outcome_sink(outcome)
 
     async def fetch(self, url: str) -> FetchResult:
-        outcome, response = await asyncio.to_thread(_http_request, self.session, url, self.timeout, None)
+        outcome, response, detail = await asyncio.to_thread(_http_request, self.session, url, self.timeout, None)
         self._record(outcome)
-        if outcome == FetchOutcome.SUCCESS or outcome not in BLOCK_LIKE:
-            return _to_result(outcome, response)
+        if outcome not in self._PROXY_ELIGIBLE:
+            return _to_result(outcome, response, detail)
 
         proxy = await self.proxy_provider.acquire(self.source)
         if proxy is None:
-            return _to_result(outcome, response)
+            return _to_result(outcome, response, detail)
 
-        proxy_outcome, proxy_response = await asyncio.to_thread(
+        proxy_outcome, proxy_response, proxy_detail = await asyncio.to_thread(
             _http_request, self.session, url, self.timeout, proxy.url
         )
         self._record(proxy_outcome)
@@ -114,7 +123,7 @@ class ProxyHttpFetcher:
             await self.proxy_provider.report_success(proxy, FetchMetrics(status_code=proxy_response.status_code))
         else:
             await self.proxy_provider.report_failure(proxy, FetchError(outcome=proxy_outcome))
-        return _to_result(proxy_outcome, proxy_response)
+        return _to_result(proxy_outcome, proxy_response, proxy_detail)
 
 
 class PlaywrightFetcher:
@@ -144,4 +153,5 @@ def raise_for_blocked(result: FetchResult, url: str) -> str:
         return result.text
     if result.outcome in BLOCK_LIKE:
         raise FetchBlockedError(result.outcome)
-    raise RuntimeError(f"Fetch failed for {url}: {result.outcome.value}")
+    suffix = f" ({result.detail})" if result.detail else ""
+    raise RuntimeError(f"Fetch failed for {url}: {result.outcome.value}{suffix}")

--- a/tests/unit/test_fetch_outcome.py
+++ b/tests/unit/test_fetch_outcome.py
@@ -35,11 +35,15 @@ def test_classify_response_captcha_page_disguised_as_403():
 
 
 def test_classify_exception_timeout():
-    assert classify_exception(requests.Timeout()) == FetchOutcome.TIMEOUT
+    outcome, detail = classify_exception(requests.Timeout("timed out"))
+    assert outcome == FetchOutcome.TIMEOUT
+    assert detail == "Timeout: timed out"
 
 
 def test_classify_exception_connection_error():
-    assert classify_exception(requests.ConnectionError()) == FetchOutcome.NETWORK_ERROR
+    outcome, detail = classify_exception(requests.ConnectionError("Connection reset by peer"))
+    assert outcome == FetchOutcome.NETWORK_ERROR
+    assert detail == "ConnectionError: Connection reset by peer"
 
 
 def test_outcome_counter_accumulates():

--- a/tests/unit/test_fetch_strategy.py
+++ b/tests/unit/test_fetch_strategy.py
@@ -109,6 +109,40 @@ async def test_proxy_http_fetcher_reports_failure_when_both_blocked(monkeypatch)
     assert len(proxy_provider.failures) == 1
 
 
+async def test_proxy_http_fetcher_retries_via_proxy_on_network_error(monkeypatch):
+    proxy_provider = FakeProxyProvider()
+    fetcher = ProxyHttpFetcher(source="polovniautomobili", proxy_provider=proxy_provider)
+
+    def fake_get(url, timeout, headers, proxies=None):
+        if proxies is None:
+            raise requests.ConnectionError("Connection reset by peer")
+        return _response(200, "via proxy")
+
+    monkeypatch.setattr(fetcher.session, "get", fake_get)
+
+    result = await fetcher.fetch("https://example.com")
+
+    assert result.outcome == FetchOutcome.SUCCESS
+    assert result.text == "via proxy"
+    assert len(proxy_provider.successes) == 1
+    assert proxy_provider.failures == []
+
+
+async def test_proxy_http_fetcher_reports_failure_when_network_error_persists_through_proxy(monkeypatch):
+    proxy_provider = FakeProxyProvider()
+    fetcher = ProxyHttpFetcher(source="polovniautomobili", proxy_provider=proxy_provider)
+    monkeypatch.setattr(
+        fetcher.session, "get", lambda *a, **kw: (_ for _ in ()).throw(requests.ConnectionError("still down"))
+    )
+
+    result = await fetcher.fetch("https://example.com")
+
+    assert result.outcome == FetchOutcome.NETWORK_ERROR
+    assert result.detail == "ConnectionError: still down"
+    assert proxy_provider.successes == []
+    assert len(proxy_provider.failures) == 1
+
+
 async def test_proxy_http_fetcher_does_not_try_proxy_on_server_error(monkeypatch):
     proxy_provider = FakeProxyProvider()
     fetcher = ProxyHttpFetcher(source="polovniautomobili", proxy_provider=proxy_provider)


### PR DESCRIPTION
## Summary
- `ProxyHttpFetcher` now also retries through the residential proxy when the direct attempt classifies as `NETWORK_ERROR` (connection refused/reset), not just the existing block-like outcomes (403/429/challenge/captcha) — a silently dropped connection can be an IP-level block that never surfaces as a proper HTTP status. `TIMEOUT`/`SERVER_ERROR` are still not retried through the proxy.
- `classify_exception()` now returns `(FetchOutcome, detail)` where `detail` is `f"{type(exc).__name__}: {exc}"`, and that detail is carried through `FetchResult` into the `RuntimeError` message `raise_for_blocked()` raises — so a `network_error`/`timeout` failure in the logs says what actually happened (DNS failure, connection reset, TLS error, ...) instead of just the bare outcome value.

Context: prod scheduled search jobs hit `network_error` on the polovniautomobili adapter and never touched the IPRoyal proxy — traced to `network_error` not being in `BLOCK_LIKE`. This closes that gap and adds the detail needed to tell a real network blip from a site-side block next time.

## Test plan
- [x] `tests/unit/test_fetch_outcome.py` — updated `classify_exception` tests for the new tuple return
- [x] `tests/unit/test_fetch_strategy.py` — added: proxy retry succeeds on network_error, proxy retry fails and detail propagates
- [x] `.venv/bin/python -m pytest tests/unit -q` — 144 passed
- [x] `ruff check` / `mypy` on changed files — clean