### PR TITLE
Add saved searches, listing follows, and notifications

### DIFF
--- a/app/api/v1/listings.py
+++ b/app/api/v1/listings.py
@@ -3,24 +3,65 @@ import uuid
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.auth.dependencies import get_current_user, get_current_user_optional, require_csrf
 from app.db.session import get_session
-from app.listings.repository import ListingRepository
+from app.listings.repository import FollowRepository, ListingRepository
 from app.listings.schemas import ListingHistoryOut, ListingOut, ListingSnapshotOut
+from app.models.listing import Listing
+from app.models.user import User
 
 router = APIRouter(prefix="/listings", tags=["listings"])
 
 
+async def _to_listing_out(listing: Listing, current_user: User | None, session: AsyncSession) -> ListingOut:
+    out = ListingOut.model_validate(listing)
+    if current_user is not None:
+        out.is_following = await FollowRepository(session).get(current_user.id, listing.id) is not None
+    return out
+
+
 @router.get("/{listing_id}", response_model=ListingOut)
-async def get_listing(listing_id: uuid.UUID, session: AsyncSession = Depends(get_session)) -> ListingOut:
+async def get_listing(
+    listing_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    current_user: User | None = Depends(get_current_user_optional),
+) -> ListingOut:
     listing = await ListingRepository(session).get_by_id(listing_id)
     if listing is None:
         raise HTTPException(status_code=404, detail="Listing not found")
-    return ListingOut.model_validate(listing)
+    return await _to_listing_out(listing, current_user, session)
+
+
+@router.post("/{listing_id}/follow", status_code=204)
+async def follow_listing(
+    listing_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+    _csrf: None = Depends(require_csrf),
+) -> None:
+    listing = await ListingRepository(session).get_by_id(listing_id)
+    if listing is None:
+        raise HTTPException(status_code=404, detail="Listing not found")
+    await FollowRepository(session).follow(current_user.id, listing_id)
+    await session.commit()
+
+
+@router.delete("/{listing_id}/follow", status_code=204)
+async def unfollow_listing(
+    listing_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+    _csrf: None = Depends(require_csrf),
+) -> None:
+    await FollowRepository(session).unfollow(current_user.id, listing_id)
+    await session.commit()
 
 
 @router.get("/{listing_id}/history", response_model=ListingHistoryOut)
 async def get_listing_history(
-    listing_id: uuid.UUID, session: AsyncSession = Depends(get_session)
+    listing_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    current_user: User | None = Depends(get_current_user_optional),
 ) -> ListingHistoryOut:
     repository = ListingRepository(session)
     listing = await repository.get_by_id(listing_id)
@@ -28,6 +69,6 @@ async def get_listing_history(
         raise HTTPException(status_code=404, detail="Listing not found")
     snapshots = await repository.get_history(listing_id)
     return ListingHistoryOut(
-        listing=ListingOut.model_validate(listing),
+        listing=await _to_listing_out(listing, current_user, session),
         snapshots=[ListingSnapshotOut.model_validate(s) for s in snapshots],
     )

--- a/app/api/v1/notifications.py
+++ b/app/api/v1/notifications.py
@@ -1,0 +1,47 @@
+import uuid
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.dependencies import get_current_user, require_csrf
+from app.db.session import get_session
+from app.models.user import User
+from app.notifications.repository import NotificationRepository
+from app.notifications.schemas import NotificationListOut, NotificationOut
+
+router = APIRouter(prefix="/me/notifications", tags=["notifications"])
+
+
+@router.get("", response_model=NotificationListOut)
+async def list_notifications(
+    session: AsyncSession = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+    limit: int = Query(default=50, ge=1, le=200),
+    offset: int = Query(default=0, ge=0),
+) -> NotificationListOut:
+    repository = NotificationRepository(session)
+    notifications = await repository.list_for_user(current_user.id, limit=limit, offset=offset)
+    unread_count = await repository.count_unread(current_user.id)
+    return NotificationListOut(
+        notifications=[NotificationOut.model_validate(n) for n in notifications],
+        unread_count=unread_count,
+    )
+
+
+@router.post("/{notification_id}/read", response_model=NotificationOut)
+async def mark_notification_read(
+    notification_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+    _csrf: None = Depends(require_csrf),
+) -> NotificationOut:
+    repository = NotificationRepository(session)
+    notification = await repository.get_owned(notification_id, current_user.id)
+    if notification is None:
+        raise HTTPException(status_code=404, detail="Notification not found")
+
+    if notification.read_at is None:
+        notification.read_at = datetime.now(timezone.utc)
+        await session.commit()
+    return NotificationOut.model_validate(notification)

--- a/app/api/v1/router.py
+++ b/app/api/v1/router.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from app.api.v1 import auth, listings, scrape, search, vehicles
+from app.api.v1 import auth, listings, notifications, saved_searches, scrape, search, vehicles
 
 api_router = APIRouter(prefix="/api/v1")
 api_router.include_router(auth.router)
@@ -9,3 +9,5 @@ api_router.include_router(search.router)
 api_router.include_router(listings.router)
 api_router.include_router(vehicles.router)
 api_router.include_router(scrape.router)
+api_router.include_router(saved_searches.router)
+api_router.include_router(notifications.router)

--- a/app/api/v1/saved_searches.py
+++ b/app/api/v1/saved_searches.py
@@ -1,0 +1,121 @@
+import uuid
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.dependencies import get_current_user, require_csrf
+from app.db.session import get_session
+from app.models.saved_search import SavedSearch
+from app.models.user import User
+from app.saved_searches.repository import MAX_FREE_SAVED_SEARCHES, SavedSearchRepository
+from app.saved_searches.schemas import SavedSearchCreate, SavedSearchOut, SavedSearchUpdate
+from app.search.query import SearchQuery, SearchRequest
+from app.search.schemas import SearchResponse
+from app.search.service import SearchService
+
+router = APIRouter(prefix="/saved-searches", tags=["saved-searches"])
+
+
+@router.get("", response_model=list[SavedSearchOut])
+async def list_saved_searches(
+    session: AsyncSession = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+) -> list[SavedSearchOut]:
+    rows = await SavedSearchRepository(session).list_for_user(current_user.id)
+    return [SavedSearchOut.model_validate(row) for row in rows]
+
+
+@router.post("", response_model=SavedSearchOut, status_code=201)
+async def create_saved_search(
+    payload: SavedSearchCreate,
+    session: AsyncSession = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+    _csrf: None = Depends(require_csrf),
+) -> SavedSearchOut:
+    repo = SavedSearchRepository(session)
+    count = await repo.count_for_user(current_user.id)
+    if count >= MAX_FREE_SAVED_SEARCHES:
+        raise HTTPException(status_code=402, detail=f"Saved search limit reached ({MAX_FREE_SAVED_SEARCHES})")
+
+    saved_search = SavedSearch(
+        user_id=current_user.id,
+        name=payload.name,
+        query=payload.query.model_dump(),
+        notification_settings=payload.notification_settings,
+    )
+    session.add(saved_search)
+    await session.commit()
+    return SavedSearchOut.model_validate(saved_search)
+
+
+@router.get("/{saved_search_id}", response_model=SavedSearchOut)
+async def get_saved_search(
+    saved_search_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+) -> SavedSearchOut:
+    saved_search = await SavedSearchRepository(session).get_owned(saved_search_id, current_user.id)
+    if saved_search is None:
+        raise HTTPException(status_code=404, detail="Saved search not found")
+    return SavedSearchOut.model_validate(saved_search)
+
+
+@router.patch("/{saved_search_id}", response_model=SavedSearchOut)
+async def update_saved_search(
+    saved_search_id: uuid.UUID,
+    payload: SavedSearchUpdate,
+    session: AsyncSession = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+    _csrf: None = Depends(require_csrf),
+) -> SavedSearchOut:
+    saved_search = await SavedSearchRepository(session).get_owned(saved_search_id, current_user.id)
+    if saved_search is None:
+        raise HTTPException(status_code=404, detail="Saved search not found")
+
+    if payload.name is not None:
+        saved_search.name = payload.name
+    if payload.query is not None:
+        saved_search.query = payload.query.model_dump()
+    if payload.enabled is not None:
+        saved_search.enabled = payload.enabled
+    if payload.notification_settings is not None:
+        saved_search.notification_settings = payload.notification_settings
+    await session.commit()
+    return SavedSearchOut.model_validate(saved_search)
+
+
+@router.delete("/{saved_search_id}", status_code=204)
+async def delete_saved_search(
+    saved_search_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+    _csrf: None = Depends(require_csrf),
+) -> None:
+    saved_search = await SavedSearchRepository(session).get_owned(saved_search_id, current_user.id)
+    if saved_search is None:
+        raise HTTPException(status_code=404, detail="Saved search not found")
+    await session.delete(saved_search)
+    await session.commit()
+
+
+@router.post("/{saved_search_id}/run", response_model=SearchResponse)
+async def run_saved_search(
+    saved_search_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+    _csrf: None = Depends(require_csrf),
+) -> SearchResponse:
+    """Runs the saved query against whatever is currently in the DB — a live view, not a fresh
+    scrape. Periodic background refresh of the underlying data is app/scraping/scheduler.py (#26).
+    """
+    saved_search = await SavedSearchRepository(session).get_owned(saved_search_id, current_user.id)
+    if saved_search is None:
+        raise HTTPException(status_code=404, detail="Saved search not found")
+
+    query = SearchQuery.model_validate(saved_search.query)
+    result = await SearchService(session).search(SearchRequest(query=query))
+
+    saved_search.last_run_at = datetime.now(timezone.utc)
+    await session.commit()
+    return result

--- a/app/auth/dependencies.py
+++ b/app/auth/dependencies.py
@@ -37,6 +37,20 @@ async def get_current_user(
     return user
 
 
+async def get_current_user_optional(
+    request: Request,
+    session: AsyncSession = Depends(get_session),
+    redis: Redis = Depends(get_redis),
+) -> User | None:
+    """Same lookup as get_current_user, but returns None instead of raising — for routes that
+    render differently for a logged-in user (e.g. an is_following flag) without requiring auth.
+    """
+    try:
+        return await get_current_user(request, session, redis)
+    except HTTPException:
+        return None
+
+
 async def require_admin(current_user: User = Depends(get_current_user)) -> User:
     if current_user.role != UserRole.ADMIN:
         raise HTTPException(status_code=403, detail="Admin access required")

--- a/app/config.py
+++ b/app/config.py
@@ -33,6 +33,10 @@ class Settings(BaseSettings):
     password_reset_rate_limit_window_seconds: int = 60 * 60
     frontend_base_url: str = "http://localhost:3000"
 
+    # Stub refresh cadence for saved searches (issue #26) — real per-plan cadence
+    # (SubscriptionPlan.refresh_frequency_minutes) is Phase 5 billing, not wired up yet.
+    saved_search_refresh_minutes: int = 60
+
     # Transactional email (verification/reset links). Unset -> falls back to a logging-only
     # sender, so local dev/CI never need real credentials. See app/auth/email.py.
     resend_api_key: str | None = None

--- a/app/listings/repository.py
+++ b/app/listings/repository.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.follow import Follow
 from app.models.listing import Listing, ListingStatus
 from app.models.snapshot import ListingSnapshot
 from app.sources.base import SourceListing
@@ -43,9 +44,11 @@ class ListingRepository:
         )
         return result.scalar_one_or_none()
 
-    async def upsert_listing(self, source_id: uuid.UUID, data: SourceListing) -> tuple[Listing, bool]:
+    async def upsert_listing(self, source_id: uuid.UUID, data: SourceListing) -> tuple[Listing, bool, int | None]:
         """Insert a new Listing + its first Snapshot, or refresh an existing one and append a new
-        Snapshot only if price/mileage/title actually changed. Returns (listing, is_new).
+        Snapshot only if price/mileage/title actually changed. Returns (listing, is_new,
+        previous_price) — previous_price is the price before this update, only set when the price
+        actually changed (used by app/notifications/matching.py to detect drops for #21/#26).
         """
         now = datetime.now(timezone.utc)
         existing = await self._find_existing(source_id, data.external_id)
@@ -78,7 +81,7 @@ class ListingRepository:
             self.session.add(listing)
             await self.session.flush()
             self._add_snapshot(listing, data, now)
-            return listing, True
+            return listing, True, None
 
         existing.last_seen_at = now
         existing.last_checked_at = now
@@ -90,13 +93,16 @@ class ListingRepository:
             or existing.mileage_km != data.mileage_km
             or existing.title != data.title
         )
+        previous_price = None
         if changed:
+            if existing.price != data.price:
+                previous_price = existing.price
             existing.price = data.price
             existing.mileage_km = data.mileage_km
             existing.title = data.title
             self._add_snapshot(existing, data, now)
 
-        return existing, False
+        return existing, False, previous_price
 
     async def mark_missing_as_removed(self, source_id: uuid.UUID, seen_external_ids: set[str]) -> int:
         """Mark active listings for a source that were not encountered in the latest crawl as
@@ -129,3 +135,36 @@ class ListingRepository:
                 raw_payload=data.raw,
             )
         )
+
+
+class FollowRepository:
+    """Owns Follow persistence — see issue #21. Notification generation on price drop lives in
+    app/notifications/matching.py, not here.
+    """
+
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def get(self, user_id: uuid.UUID, listing_id: uuid.UUID) -> Follow | None:
+        result = await self.session.execute(
+            select(Follow).where(Follow.user_id == user_id, Follow.listing_id == listing_id)
+        )
+        return result.scalar_one_or_none()
+
+    async def follow(self, user_id: uuid.UUID, listing_id: uuid.UUID) -> Follow:
+        existing = await self.get(user_id, listing_id)
+        if existing is not None:
+            return existing
+        follow = Follow(user_id=user_id, listing_id=listing_id)
+        self.session.add(follow)
+        await self.session.flush()
+        return follow
+
+    async def unfollow(self, user_id: uuid.UUID, listing_id: uuid.UUID) -> None:
+        existing = await self.get(user_id, listing_id)
+        if existing is not None:
+            await self.session.delete(existing)
+
+    async def list_followers(self, listing_id: uuid.UUID) -> list[Follow]:
+        result = await self.session.execute(select(Follow).where(Follow.listing_id == listing_id))
+        return list(result.scalars().all())

--- a/app/listings/schemas.py
+++ b/app/listings/schemas.py
@@ -31,6 +31,9 @@ class ListingOut(BaseModel):
     first_seen_at: datetime
     last_seen_at: datetime
     last_checked_at: datetime
+    # Set by the route for a logged-in caller (app/listings/repository.py::FollowRepository),
+    # never derived from the Listing row itself.
+    is_following: bool = False
 
 
 class ListingSnapshotOut(BaseModel):

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,5 +1,6 @@
 """Import every model module so `Base.metadata` (and Alembic autogenerate) sees all tables."""
 
+from app.models.follow import Follow
 from app.models.listing import Listing, ListingStatus
 from app.models.notification import Notification, NotificationType
 from app.models.saved_search import SavedSearch
@@ -17,6 +18,7 @@ __all__ = [
     "Listing",
     "ListingStatus",
     "ListingSnapshot",
+    "Follow",
     "User",
     "SavedSearch",
     "ScheduledScrape",

--- a/app/models/follow.py
+++ b/app/models/follow.py
@@ -1,0 +1,19 @@
+import uuid
+
+from sqlalchemy import ForeignKey, UniqueConstraint, Uuid
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+from app.models.mixins import TimestampMixin, UUIDPkMixin
+
+# A user subscribing to price-drop alerts for one listing. See issue #21 — the notification event
+# itself (PRICE_DROP) is generated in app/notifications/matching.py once a scrape sees the price
+# decrease, not here; this table only records the subscription.
+
+
+class Follow(UUIDPkMixin, TimestampMixin, Base):
+    __tablename__ = "follows"
+    __table_args__ = (UniqueConstraint("user_id", "listing_id", name="uq_follows_user_id_listing_id"),)
+
+    user_id: Mapped[uuid.UUID] = mapped_column(Uuid, ForeignKey("users.id"), nullable=False, index=True)
+    listing_id: Mapped[uuid.UUID] = mapped_column(Uuid, ForeignKey("listings.id"), nullable=False, index=True)

--- a/app/models/notification.py
+++ b/app/models/notification.py
@@ -24,5 +24,9 @@ class Notification(UUIDPkMixin, TimestampMixin, Base):
 
     user_id: Mapped[uuid.UUID] = mapped_column(Uuid, ForeignKey("users.id"), nullable=False, index=True)
     type: Mapped[NotificationType] = mapped_column(Enum(NotificationType, native_enum=False, length=32), nullable=False)
+    # Set for listing-scoped events (NEW_MATCH/PRICE_DROP/LISTING_REMOVED); backs the send cooldown
+    # in app/notifications/service.py and lets the UI link straight to the listing. MARKET_CHANGE
+    # (a market-segment event, not one listing) is expected to leave this null.
+    listing_id: Mapped[uuid.UUID | None] = mapped_column(Uuid, ForeignKey("listings.id"), nullable=True, index=True)
     payload: Mapped[dict | None] = mapped_column(JSON, nullable=True)
     read_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/app/notifications/__init__.py
+++ b/app/notifications/__init__.py
@@ -1,1 +1,5 @@
-"""No delivery (email/in-app) yet — model is app.models.notification.Notification (schema only)."""
+"""Notification creation (app/notifications/service.py), in-app read/list API
+(app/api/v1/notifications.py) and email delivery (app/notifications/delivery.py). The actual
+events — NEW_MATCH from saved searches, PRICE_DROP from follows — are generated from the scrape
+pipeline in app/notifications/matching.py (issue #26).
+"""

--- a/app/notifications/delivery.py
+++ b/app/notifications/delivery.py
@@ -24,15 +24,23 @@ def _saved_search_url(saved_search_id: str | None) -> str:
     return f"{get_settings().frontend_base_url}/saved-searches/{saved_search_id}"
 
 
-def _new_listings_phrase(count: int) -> str:
-    """Russian noun/adjective agreement for "N new listings": 1 новое объявление, 2-4 новых
-    объявления, 5+ (and the -11..-14 teens exception) новых объявлений.
+def _listings_noun(count: int) -> str:
+    """Russian noun plural forms: 1 объявление, 2-4 объявления, 5+ (and the -11..-14 teens
+    exception) объявлений.
     """
     if count % 10 == 1 and count % 100 != 11:
-        return f"{count} новое объявление"
+        return "объявление"
     if 2 <= count % 10 <= 4 and not (12 <= count % 100 <= 14):
-        return f"{count} новых объявления"
-    return f"{count} новых объявлений"
+        return "объявления"
+    return "объявлений"
+
+
+def _new_listings_phrase(count: int) -> str:
+    """Russian adjective agreement on top of _listings_noun: "N новое объявление"/"N новых
+    объявления"/"N новых объявлений".
+    """
+    adjective = "новое" if count % 10 == 1 and count % 100 != 11 else "новых"
+    return f"{count} {adjective} {_listings_noun(count)}"
 
 
 def render_notification(notification: Notification) -> tuple[str, str]:
@@ -41,12 +49,21 @@ def render_notification(notification: Notification) -> tuple[str, str]:
 
     if notification.type == NotificationType.NEW_MATCH:
         name = payload.get("saved_search_name", "Сохранённый поиск")
-        count = payload.get("new_listings_count", 0)
+        new_count = payload.get("new_listings_count", 0)
+        updated_count = payload.get("updated_listings_count", 0)
         description = payload.get("query_description", "")
         search_url = _saved_search_url(payload.get("saved_search_id"))
-        phrase = _new_listings_phrase(count)
-        subject = f"«{name}»: {phrase}"
-        body = f"По вашему поиску «{name}» ({description}) появилось: {phrase}.\n\nСмотреть: {search_url}"
+
+        if new_count:
+            subject = f"«{name}»: {_new_listings_phrase(new_count)}"
+        else:
+            subject = f"«{name}»: обновлено {updated_count} {_listings_noun(updated_count)}"
+
+        lines = [f"По вашему поиску «{name}» ({description}):", f"Новых объявлений: {new_count}"]
+        if updated_count:
+            lines.append(f"Обновлено объявлений: {updated_count}")
+        lines += ["", f"Смотреть: {search_url}"]
+        body = "\n".join(lines)
         return subject, body
 
     if notification.type == NotificationType.PRICE_DROP:

--- a/app/notifications/delivery.py
+++ b/app/notifications/delivery.py
@@ -18,16 +18,35 @@ def _listing_url(listing_id: uuid.UUID | None) -> str:
     return f"{get_settings().frontend_base_url}/listings/{listing_id}"
 
 
+def _saved_search_url(saved_search_id: str | None) -> str:
+    if not saved_search_id:
+        return f"{get_settings().frontend_base_url}/saved-searches"
+    return f"{get_settings().frontend_base_url}/saved-searches/{saved_search_id}"
+
+
+def _new_listings_phrase(count: int) -> str:
+    """Russian noun/adjective agreement for "N new listings": 1 новое объявление, 2-4 новых
+    объявления, 5+ (and the -11..-14 teens exception) новых объявлений.
+    """
+    if count % 10 == 1 and count % 100 != 11:
+        return f"{count} новое объявление"
+    if 2 <= count % 10 <= 4 and not (12 <= count % 100 <= 14):
+        return f"{count} новых объявления"
+    return f"{count} новых объявлений"
+
+
 def render_notification(notification: Notification) -> tuple[str, str]:
     payload = notification.payload or {}
     url = _listing_url(notification.listing_id)
 
     if notification.type == NotificationType.NEW_MATCH:
-        title = payload.get("listing_title", "Новое объявление")
-        price = payload.get("listing_price")
-        currency = payload.get("currency", "")
-        subject = f"Новое совпадение: {title}"
-        body = f"{title}\n{price} {currency}\n\nСохранённый поиск: {payload.get('saved_search_name', '')}\n{url}"
+        name = payload.get("saved_search_name", "Сохранённый поиск")
+        count = payload.get("new_listings_count", 0)
+        description = payload.get("query_description", "")
+        search_url = _saved_search_url(payload.get("saved_search_id"))
+        phrase = _new_listings_phrase(count)
+        subject = f"«{name}»: {phrase}"
+        body = f"По вашему поиску «{name}» ({description}) появилось: {phrase}.\n\nСмотреть: {search_url}"
         return subject, body
 
     if notification.type == NotificationType.PRICE_DROP:

--- a/app/notifications/delivery.py
+++ b/app/notifications/delivery.py
@@ -1,0 +1,66 @@
+"""Renders and sends the email side of a Notification. Registered as an arq task in
+app/scraping/worker.py so a slow/failing SMTP call never blocks or fails the scrape job that
+triggered it (see issue #22's isolation requirement).
+"""
+
+import uuid
+from typing import Any
+
+from app.auth.email import EmailSender
+from app.auth.repository import UserRepository
+from app.config import get_settings
+from app.models.notification import Notification, NotificationType
+
+
+def _listing_url(listing_id: uuid.UUID | None) -> str:
+    if listing_id is None:
+        return ""
+    return f"{get_settings().frontend_base_url}/listings/{listing_id}"
+
+
+def render_notification(notification: Notification) -> tuple[str, str]:
+    payload = notification.payload or {}
+    url = _listing_url(notification.listing_id)
+
+    if notification.type == NotificationType.NEW_MATCH:
+        title = payload.get("listing_title", "Новое объявление")
+        price = payload.get("listing_price")
+        currency = payload.get("currency", "")
+        subject = f"Новое совпадение: {title}"
+        body = f"{title}\n{price} {currency}\n\nСохранённый поиск: {payload.get('saved_search_name', '')}\n{url}"
+        return subject, body
+
+    if notification.type == NotificationType.PRICE_DROP:
+        title = payload.get("listing_title", "Объявление")
+        previous = payload.get("previous_price")
+        current = payload.get("current_price")
+        currency = payload.get("currency", "")
+        subject = f"Цена снижена: {title}"
+        body = f"{title}\nБыло: {previous} {currency}\nСтало: {current} {currency}\n{url}"
+        return subject, body
+
+    if notification.type == NotificationType.LISTING_REMOVED:
+        title = payload.get("listing_title", "Объявление")
+        subject = f"Объявление снято с публикации: {title}"
+        body = f"{title}\n{url}"
+        return subject, body
+
+    subject = "Изменение на рынке"
+    body = payload.get("description", "")
+    return subject, body
+
+
+async def send_notification_email(ctx: dict[str, Any], notification_id: str) -> None:
+    session_factory = ctx["session_factory"]
+    email_sender: EmailSender = ctx["email_sender"]
+
+    async with session_factory() as session:
+        notification = await session.get(Notification, uuid.UUID(notification_id))
+        if notification is None:
+            return
+        user = await UserRepository(session).get_by_id(notification.user_id)
+        if user is None:
+            return
+
+        subject, body = render_notification(notification)
+        await email_sender.send(to=user.email, subject=subject, body=body)

--- a/app/notifications/matching.py
+++ b/app/notifications/matching.py
@@ -67,11 +67,11 @@ async def _find_matching_saved_searches(session: AsyncSession, query_hash: str) 
 async def _notify_new_matches(
     session: AsyncSession, service: NotificationService, job: ScrapeJob, stats: ScrapeStats
 ) -> None:
-    """One notification per (saved search, scrape run) — "N new listings for X" — not one per
-    listing. Every new listing this run matched the same job query, which is exactly the saved
-    search's query, so the count is the same for every saved search that matches it.
+    """One notification per (saved search, scrape run) — "N new, M updated for X" — not one per
+    listing. Every listing this run (new or updated) matched the same job query, which is exactly
+    the saved search's query, so both counts are the same for every saved search that matches it.
     """
-    if not stats.new_listing_ids:
+    if not stats.new_listing_ids and not stats.listings_updated:
         return
 
     job_query, _ = decode_job_query(job.query)
@@ -79,7 +79,8 @@ async def _notify_new_matches(
     if not matching_saved_searches:
         return
 
-    count = len(stats.new_listing_ids)
+    new_count = len(stats.new_listing_ids)
+    updated_count = stats.listings_updated
     for saved_search in matching_saved_searches:
         await service.notify(
             saved_search.user_id,
@@ -87,7 +88,8 @@ async def _notify_new_matches(
             {
                 "saved_search_id": str(saved_search.id),
                 "saved_search_name": saved_search.name,
-                "new_listings_count": count,
+                "new_listings_count": new_count,
+                "updated_listings_count": updated_count,
                 "query_description": job_query.describe(),
             },
         )

--- a/app/notifications/matching.py
+++ b/app/notifications/matching.py
@@ -67,6 +67,10 @@ async def _find_matching_saved_searches(session: AsyncSession, query_hash: str) 
 async def _notify_new_matches(
     session: AsyncSession, service: NotificationService, job: ScrapeJob, stats: ScrapeStats
 ) -> None:
+    """One notification per (saved search, scrape run) — "N new listings for X" — not one per
+    listing. Every new listing this run matched the same job query, which is exactly the saved
+    search's query, so the count is the same for every saved search that matches it.
+    """
     if not stats.new_listing_ids:
         return
 
@@ -75,19 +79,15 @@ async def _notify_new_matches(
     if not matching_saved_searches:
         return
 
-    for listing_id in stats.new_listing_ids:
-        listing = await session.get(Listing, listing_id)
-        if listing is None:
-            continue
-        for saved_search in matching_saved_searches:
-            await service.notify(
-                saved_search.user_id,
-                NotificationType.NEW_MATCH,
-                {
-                    "listing_title": listing.title,
-                    "listing_price": listing.price,
-                    "currency": listing.currency,
-                    "saved_search_name": saved_search.name,
-                },
-                listing_id=listing_id,
-            )
+    count = len(stats.new_listing_ids)
+    for saved_search in matching_saved_searches:
+        await service.notify(
+            saved_search.user_id,
+            NotificationType.NEW_MATCH,
+            {
+                "saved_search_id": str(saved_search.id),
+                "saved_search_name": saved_search.name,
+                "new_listings_count": count,
+                "query_description": job_query.describe(),
+            },
+        )

--- a/app/notifications/matching.py
+++ b/app/notifications/matching.py
@@ -1,0 +1,93 @@
+"""Turns one scrape run's per-listing results (app/scraping/pipeline.py::ScrapeStats) into
+Notification rows — the "alert strictly after we've scraped new data" step called from
+app/scraping/worker.py::run_scrape_job once a job finishes. See issues #21 (PRICE_DROP via
+Follow) and #26 (NEW_MATCH via SavedSearch).
+"""
+
+from collections.abc import Awaitable, Callable
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.listings.repository import FollowRepository
+from app.models.listing import Listing
+from app.models.notification import NotificationType
+from app.models.saved_search import SavedSearch
+from app.models.scrape_job import ScrapeJob
+from app.notifications.service import NotificationService
+from app.scraping.pipeline import ScrapeStats
+from app.scraping.schemas import decode_job_query
+from app.search.query import SearchQuery
+
+EmailEnqueuer = Callable[[str], Awaitable[None]]
+
+
+async def generate_notifications_for_job(
+    session: AsyncSession,
+    job: ScrapeJob,
+    stats: ScrapeStats,
+    enqueue_email: EmailEnqueuer | None = None,
+) -> None:
+    service = NotificationService(session, enqueue_email=enqueue_email)
+    await _notify_price_drops(session, service, stats)
+    await _notify_new_matches(session, service, job, stats)
+
+
+async def _notify_price_drops(session: AsyncSession, service: NotificationService, stats: ScrapeStats) -> None:
+    if not stats.price_drops:
+        return
+    follow_repository = FollowRepository(session)
+    for listing_id, previous_price, current_price in stats.price_drops:
+        listing = await session.get(Listing, listing_id)
+        if listing is None:
+            continue
+        for follow in await follow_repository.list_followers(listing_id):
+            await service.notify(
+                follow.user_id,
+                NotificationType.PRICE_DROP,
+                {
+                    "listing_title": listing.title,
+                    "previous_price": previous_price,
+                    "current_price": current_price,
+                    "currency": listing.currency,
+                },
+                listing_id=listing_id,
+            )
+
+
+async def _find_matching_saved_searches(session: AsyncSession, query_hash: str) -> list[SavedSearch]:
+    result = await session.execute(select(SavedSearch).where(SavedSearch.enabled.is_(True)))
+    return [
+        saved_search
+        for saved_search in result.scalars().all()
+        if SearchQuery.model_validate(saved_search.query).stable_hash() == query_hash
+    ]
+
+
+async def _notify_new_matches(
+    session: AsyncSession, service: NotificationService, job: ScrapeJob, stats: ScrapeStats
+) -> None:
+    if not stats.new_listing_ids:
+        return
+
+    job_query, _ = decode_job_query(job.query)
+    matching_saved_searches = await _find_matching_saved_searches(session, job_query.stable_hash())
+    if not matching_saved_searches:
+        return
+
+    for listing_id in stats.new_listing_ids:
+        listing = await session.get(Listing, listing_id)
+        if listing is None:
+            continue
+        for saved_search in matching_saved_searches:
+            await service.notify(
+                saved_search.user_id,
+                NotificationType.NEW_MATCH,
+                {
+                    "listing_title": listing.title,
+                    "listing_price": listing.price,
+                    "currency": listing.currency,
+                    "saved_search_name": saved_search.name,
+                },
+                listing_id=listing_id,
+            )

--- a/app/notifications/repository.py
+++ b/app/notifications/repository.py
@@ -1,0 +1,56 @@
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.notification import Notification, NotificationType
+
+
+class NotificationRepository:
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def list_for_user(self, user_id: uuid.UUID, limit: int = 50, offset: int = 0) -> list[Notification]:
+        result = await self.session.execute(
+            select(Notification)
+            .where(Notification.user_id == user_id)
+            .order_by(Notification.created_at.desc())
+            .limit(limit)
+            .offset(offset)
+        )
+        return list(result.scalars().all())
+
+    async def count_unread(self, user_id: uuid.UUID) -> int:
+        result = await self.session.execute(
+            select(func.count())
+            .select_from(Notification)
+            .where(Notification.user_id == user_id, Notification.read_at.is_(None))
+        )
+        return result.scalar_one()
+
+    async def get_owned(self, notification_id: uuid.UUID, user_id: uuid.UUID) -> Notification | None:
+        result = await self.session.execute(
+            select(Notification).where(Notification.id == notification_id, Notification.user_id == user_id)
+        )
+        return result.scalar_one_or_none()
+
+    async def recent_duplicate_exists(
+        self, user_id: uuid.UUID, type: NotificationType, listing_id: uuid.UUID, cooldown: timedelta
+    ) -> bool:
+        """Backs the "same event, cooldown" rule in issue #22 — a listing that keeps re-triggering
+        the same event type (e.g. a job re-checking the same saved search) shouldn't re-notify the
+        user every run.
+        """
+        since = datetime.now(timezone.utc) - cooldown
+        result = await self.session.execute(
+            select(Notification.id)
+            .where(
+                Notification.user_id == user_id,
+                Notification.type == type,
+                Notification.listing_id == listing_id,
+                Notification.created_at >= since,
+            )
+            .limit(1)
+        )
+        return result.scalar_one_or_none() is not None

--- a/app/notifications/schemas.py
+++ b/app/notifications/schemas.py
@@ -1,0 +1,22 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+from app.models.notification import NotificationType
+
+
+class NotificationOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    type: NotificationType
+    listing_id: uuid.UUID | None
+    payload: dict | None
+    read_at: datetime | None
+    created_at: datetime
+
+
+class NotificationListOut(BaseModel):
+    notifications: list[NotificationOut]
+    unread_count: int

--- a/app/notifications/service.py
+++ b/app/notifications/service.py
@@ -1,0 +1,50 @@
+import uuid
+from collections.abc import Awaitable, Callable
+from datetime import timedelta
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.notification import Notification, NotificationType
+from app.notifications.repository import NotificationRepository
+
+_DEFAULT_COOLDOWN = timedelta(hours=24)
+
+EmailEnqueuer = Callable[[str], Awaitable[None]]
+
+
+class NotificationService:
+    """Single entry point for creating a Notification — both the scrape pipeline's post-run
+    matching (issue #26/#21) and any future manual trigger should go through this, not
+    `session.add(Notification(...))` directly, so the cooldown/email-enqueue rules always apply.
+    """
+
+    def __init__(self, session: AsyncSession, enqueue_email: EmailEnqueuer | None = None):
+        self.session = session
+        self.repository = NotificationRepository(session)
+        self.enqueue_email = enqueue_email
+
+    async def notify(
+        self,
+        user_id: uuid.UUID,
+        type: NotificationType,
+        payload: dict,
+        listing_id: uuid.UUID | None = None,
+        cooldown: timedelta = _DEFAULT_COOLDOWN,
+    ) -> Notification | None:
+        """Returns None (and creates nothing) if an equivalent notification already fired within
+        `cooldown` — only checked for listing-scoped events, since that's the only case with a
+        natural dedup key (user, type, listing).
+        """
+        if listing_id is not None:
+            duplicate = await self.repository.recent_duplicate_exists(user_id, type, listing_id, cooldown)
+            if duplicate:
+                return None
+
+        notification = Notification(user_id=user_id, type=type, listing_id=listing_id, payload=payload)
+        self.session.add(notification)
+        await self.session.flush()
+
+        if self.enqueue_email is not None:
+            await self.enqueue_email(str(notification.id))
+
+        return notification

--- a/app/saved_searches/__init__.py
+++ b/app/saved_searches/__init__.py
@@ -1,1 +1,3 @@
-"""No service/repository/routes yet — model is app.models.saved_search.SavedSearch (schema only)."""
+"""CRUD + run for SavedSearch. See app/api/v1/saved_searches.py and app/saved_searches/repository.py.
+Periodic refresh scheduling lives in app/scraping/scheduler.py (issue #26).
+"""

--- a/app/saved_searches/repository.py
+++ b/app/saved_searches/repository.py
@@ -1,0 +1,46 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import func, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.saved_search import SavedSearch
+
+# Stub free-plan limit — real per-plan enforcement (SubscriptionPlan.max_saved_searches) is
+# Phase 5 billing (issues #43-47), not wired up yet.
+MAX_FREE_SAVED_SEARCHES = 5
+
+
+class SavedSearchRepository:
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def list_for_user(self, user_id: uuid.UUID) -> list[SavedSearch]:
+        result = await self.session.execute(
+            select(SavedSearch).where(SavedSearch.user_id == user_id).order_by(SavedSearch.created_at.desc())
+        )
+        return list(result.scalars().all())
+
+    async def get_owned(self, saved_search_id: uuid.UUID, user_id: uuid.UUID) -> SavedSearch | None:
+        result = await self.session.execute(
+            select(SavedSearch).where(SavedSearch.id == saved_search_id, SavedSearch.user_id == user_id)
+        )
+        return result.scalar_one_or_none()
+
+    async def count_for_user(self, user_id: uuid.UUID) -> int:
+        result = await self.session.execute(
+            select(func.count()).select_from(SavedSearch).where(SavedSearch.user_id == user_id)
+        )
+        return result.scalar_one()
+
+    async def list_due(self, cutoff: datetime) -> list[SavedSearch]:
+        """Enabled saved searches never refreshed, or last refreshed before `cutoff` — backs the
+        periodic-refresh cron in app/scraping/scheduler.py (#26).
+        """
+        result = await self.session.execute(
+            select(SavedSearch).where(
+                SavedSearch.enabled.is_(True),
+                or_(SavedSearch.last_run_at.is_(None), SavedSearch.last_run_at <= cutoff),
+            )
+        )
+        return list(result.scalars().all())

--- a/app/saved_searches/schemas.py
+++ b/app/saved_searches/schemas.py
@@ -1,0 +1,31 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.search.query import SearchQuery
+
+
+class SavedSearchCreate(BaseModel):
+    name: str
+    query: SearchQuery = Field(default_factory=SearchQuery)
+    notification_settings: dict | None = None
+
+
+class SavedSearchUpdate(BaseModel):
+    name: str | None = None
+    query: SearchQuery | None = None
+    enabled: bool | None = None
+    notification_settings: dict | None = None
+
+
+class SavedSearchOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    name: str
+    query: dict
+    enabled: bool
+    notification_settings: dict | None
+    last_run_at: datetime | None
+    created_at: datetime

--- a/app/scraping/pipeline.py
+++ b/app/scraping/pipeline.py
@@ -2,6 +2,7 @@
 for local dev) or from an arq job (app/scraping/worker.py).
 """
 
+import uuid
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 
@@ -24,6 +25,11 @@ class ScrapeStats:
     listings_updated: int = 0
     outcome_counts: dict[str, int] = field(default_factory=dict)
     blocked: bool = False
+    # Per-listing detail the aggregate counts above don't carry — consumed by
+    # app/notifications/matching.py (issues #21/#26) to generate NEW_MATCH/PRICE_DROP events
+    # without re-querying "what changed this run".
+    new_listing_ids: list[uuid.UUID] = field(default_factory=list)
+    price_drops: list[tuple[uuid.UUID, int, int]] = field(default_factory=list)  # (listing_id, previous, current)
 
 
 async def get_or_create_source(session: AsyncSession, code: str, name: str, domain: str, country: str) -> Source:
@@ -71,11 +77,14 @@ async def run_scrape(
     try:
         async for source_listing in _search_listings(adapter, query):
             stats.listings_seen += 1
-            _, is_new = await repository.upsert_listing(source.id, source_listing)
+            listing, is_new, previous_price = await repository.upsert_listing(source.id, source_listing)
             if is_new:
                 stats.listings_created += 1
+                stats.new_listing_ids.append(listing.id)
             else:
                 stats.listings_updated += 1
+                if previous_price is not None and previous_price > listing.price:
+                    stats.price_drops.append((listing.id, previous_price, listing.price))
     except FetchBlockedError:
         # Stop pagination early but keep whatever was already upserted this run — a partial
         # result is more useful than losing it, and burning further proxy/direct requests against

--- a/app/scraping/scheduler.py
+++ b/app/scraping/scheduler.py
@@ -1,6 +1,6 @@
-"""arq cron job: creates and enqueues a ScrapeJob for every due ScheduledScrape, then advances
-next_run_at. Runs inside the same worker process as run_scrape_job (see app/scraping/worker.py) —
-no separate scheduler container needed for this simple, interval-based schedule.
+"""arq cron jobs that turn "it's time to refresh X" into an enqueued ScrapeJob. Runs inside the
+same worker process as run_scrape_job (see app/scraping/worker.py) — no separate scheduler
+container needed for either of these simple, interval-based schedules.
 """
 
 from datetime import datetime, timedelta, timezone
@@ -8,8 +8,15 @@ from typing import Any
 
 from sqlalchemy import select
 
+from app.config import get_settings
 from app.models.scheduled_scrape import ScheduledScrape
 from app.models.scrape_job import ScrapeJob, ScrapeJobStatus, ScrapeJobType
+from app.models.source import Source
+from app.saved_searches.repository import SavedSearchRepository
+from app.scraping.schemas import encode_job_query
+from app.search.query import SearchQuery
+
+_SAVED_SEARCH_MAX_PAGES = 5
 
 
 async def run_due_scheduled_scrapes(ctx: dict[str, Any]) -> None:
@@ -36,3 +43,36 @@ async def run_due_scheduled_scrapes(ctx: dict[str, Any]) -> None:
             await session.commit()
 
             await ctx["redis"].enqueue_job("run_scrape_job", str(job.id))
+
+
+async def run_due_saved_search_scrapes(ctx: dict[str, Any]) -> None:
+    """One ScrapeJob per (due SavedSearch, enabled Source) — see issue #26. Matches by *filters*,
+    not by a source the saved search doesn't itself know about, so this already extends past
+    Phase 1's single source without changes once more Source rows exist (Phase 4).
+    """
+    session_factory = ctx["session_factory"]
+    now = datetime.now(timezone.utc)
+    cutoff = now - timedelta(minutes=get_settings().saved_search_refresh_minutes)
+
+    async with session_factory() as session:
+        due_saved_searches = await SavedSearchRepository(session).list_due(cutoff)
+        if not due_saved_searches:
+            return
+
+        sources = (await session.execute(select(Source).where(Source.enabled.is_(True)))).scalars().all()
+
+        for saved_search in due_saved_searches:
+            search_query = SearchQuery.model_validate(saved_search.query)
+            for source in sources:
+                job = ScrapeJob(
+                    source_id=source.id,
+                    job_type=ScrapeJobType.SAVED_SEARCH_REFRESH,
+                    status=ScrapeJobStatus.PENDING,
+                    query=encode_job_query(search_query, max_pages=_SAVED_SEARCH_MAX_PAGES),
+                )
+                session.add(job)
+                await session.flush()
+                await ctx["redis"].enqueue_job("run_scrape_job", str(job.id))
+
+            saved_search.last_run_at = now
+            await session.commit()

--- a/app/scraping/worker.py
+++ b/app/scraping/worker.py
@@ -12,19 +12,23 @@ from typing import Any
 from arq import cron
 from arq.connections import RedisSettings
 
+from app.auth.email import get_email_sender
 from app.config import get_settings
 from app.db.session import get_session_factory
 from app.models.scrape_job import ScrapeJob, ScrapeJobStatus
 from app.models.source import Source
+from app.notifications.delivery import send_notification_email
+from app.notifications.matching import generate_notifications_for_job
 from app.scraping.pipeline import run_scrape
 from app.scraping.proxy import get_proxy_provider
-from app.scraping.scheduler import run_due_scheduled_scrapes
+from app.scraping.scheduler import run_due_saved_search_scrapes, run_due_scheduled_scrapes
 from app.scraping.schemas import decode_job_query
 
 
 async def _on_startup(ctx: dict[str, Any]) -> None:
     ctx["session_factory"] = get_session_factory()
     ctx["proxy_provider"] = get_proxy_provider()
+    ctx["email_sender"] = get_email_sender()
 
 
 async def run_scrape_job(ctx: dict[str, Any], job_id: str) -> None:
@@ -59,6 +63,11 @@ async def run_scrape_job(ctx: dict[str, Any], job_id: str) -> None:
             await session.commit()
             raise
 
+        async def _enqueue_notification_email(notification_id: str) -> None:
+            await ctx["redis"].enqueue_job("send_notification_email", notification_id)
+
+        await generate_notifications_for_job(session, job, stats, enqueue_email=_enqueue_notification_email)
+
         job.status = ScrapeJobStatus.PARTIAL if stats.blocked else ScrapeJobStatus.COMPLETED
         job.stats = {
             "listings_seen": stats.listings_seen,
@@ -71,7 +80,7 @@ async def run_scrape_job(ctx: dict[str, Any], job_id: str) -> None:
 
 
 class WorkerSettings:
-    functions = [run_scrape_job]
-    cron_jobs = [cron(run_due_scheduled_scrapes, second=0)]
+    functions = [run_scrape_job, send_notification_email]
+    cron_jobs = [cron(run_due_scheduled_scrapes, second=0), cron(run_due_saved_search_scrapes, second=0)]
     on_startup = _on_startup
     redis_settings = RedisSettings.from_dsn(get_settings().redis_url)

--- a/app/search/query.py
+++ b/app/search/query.py
@@ -36,6 +36,22 @@ class SearchQuery(BaseModel):
         canonical = json.dumps(self.model_dump(exclude_none=True), sort_keys=True, default=str)
         return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
+    def describe(self) -> str:
+        """Short human-readable summary of the active filters — used in the NEW_MATCH email
+        (app/notifications/delivery.py) so "N new listings" comes with what was actually searched
+        for. Mirrors frontend/src/pages/SavedSearchesPage.tsx's describeQuery().
+        """
+        parts: list[str] = []
+        if self.make:
+            parts.append(self.make)
+        if self.models:
+            parts.append("/".join(self.models))
+        if self.year_min or self.year_max:
+            parts.append(f"{self.year_min or '…'}–{self.year_max or '…'}")
+        if self.price_min or self.price_max:
+            parts.append(f"€{self.price_min or '…'}–{self.price_max or '…'}")
+        return ", ".join(parts) if parts else "все объявления"
+
 
 class SearchRequest(BaseModel):
     query: SearchQuery = Field(default_factory=SearchQuery)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,12 +1,15 @@
 import { Route, Routes } from 'react-router-dom'
 import { RequireAdmin } from './admin/RequireAdmin'
+import { RequireAuth } from './auth/RequireAuth'
 import { Layout } from './components/Layout'
 import { AdminJobsPage } from './pages/AdminJobsPage'
 import { ForgotPasswordPage } from './pages/ForgotPasswordPage'
 import { ListingDetailPage } from './pages/ListingDetailPage'
 import { LoginPage } from './pages/LoginPage'
+import { NotificationsPage } from './pages/NotificationsPage'
 import { RegisterPage } from './pages/RegisterPage'
 import { ResetPasswordPage } from './pages/ResetPasswordPage'
+import { SavedSearchesPage } from './pages/SavedSearchesPage'
 import { SearchPage } from './pages/SearchPage'
 import { VerifyEmailPage } from './pages/VerifyEmailPage'
 
@@ -16,6 +19,10 @@ export function App() {
       <Route element={<Layout />}>
         <Route path="/" element={<SearchPage />} />
         <Route path="/listings/:id" element={<ListingDetailPage />} />
+        <Route element={<RequireAuth />}>
+          <Route path="/saved-searches" element={<SavedSearchesPage />} />
+          <Route path="/notifications" element={<NotificationsPage />} />
+        </Route>
         <Route path="/login" element={<LoginPage />} />
         <Route path="/register" element={<RegisterPage />} />
         <Route path="/forgot-password" element={<ForgotPasswordPage />} />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import { ForgotPasswordPage } from './pages/ForgotPasswordPage'
 import { ListingDetailPage } from './pages/ListingDetailPage'
 import { LoginPage } from './pages/LoginPage'
 import { NotificationsPage } from './pages/NotificationsPage'
+import { OpenSavedSearchPage } from './pages/OpenSavedSearchPage'
 import { RegisterPage } from './pages/RegisterPage'
 import { ResetPasswordPage } from './pages/ResetPasswordPage'
 import { SavedSearchesPage } from './pages/SavedSearchesPage'
@@ -21,6 +22,7 @@ export function App() {
         <Route path="/listings/:id" element={<ListingDetailPage />} />
         <Route element={<RequireAuth />}>
           <Route path="/saved-searches" element={<SavedSearchesPage />} />
+          <Route path="/saved-searches/:id" element={<OpenSavedSearchPage />} />
           <Route path="/notifications" element={<NotificationsPage />} />
         </Route>
         <Route path="/login" element={<LoginPage />} />

--- a/frontend/src/auth/RequireAuth.tsx
+++ b/frontend/src/auth/RequireAuth.tsx
@@ -1,0 +1,11 @@
+import { Navigate, Outlet } from 'react-router-dom'
+import { useCurrentUser } from './useCurrentUser'
+
+export function RequireAuth() {
+  const { user, isLoading } = useCurrentUser()
+
+  if (isLoading) return null
+  if (!user) return <Navigate to="/login" replace />
+
+  return <Outlet />
+}

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,13 +1,23 @@
+import { useQuery } from '@tanstack/react-query'
 import { useState } from 'react'
 import { Link, Outlet, useNavigate } from 'react-router-dom'
 import { useCurrentUser, useInvalidateCurrentUser } from '../auth/useCurrentUser'
 import { authApi } from '../lib/api'
+import { notificationsApi } from '../lib/notifications'
 
 export function Layout() {
   const { user, isLoading } = useCurrentUser()
   const invalidateCurrentUser = useInvalidateCurrentUser()
   const navigate = useNavigate()
   const [isLoggingOut, setIsLoggingOut] = useState(false)
+
+  const notificationsQuery = useQuery({
+    queryKey: ['notifications'],
+    queryFn: notificationsApi.list,
+    enabled: Boolean(user),
+    refetchInterval: 60_000,
+  })
+  const unreadCount = notificationsQuery.data?.unread_count ?? 0
 
   async function handleLogout() {
     setIsLoggingOut(true)
@@ -30,6 +40,17 @@ export function Layout() {
           <nav className="flex items-center gap-4 text-sm">
             {isLoading ? null : user ? (
               <>
+                <Link to="/saved-searches" className="font-medium text-slate-700 hover:text-slate-900">
+                  Мои поиски
+                </Link>
+                <Link to="/notifications" className="relative font-medium text-slate-700 hover:text-slate-900">
+                  Уведомления
+                  {unreadCount > 0 && (
+                    <span className="ml-1 rounded-full bg-red-600 px-1.5 py-0.5 text-xs font-semibold text-white">
+                      {unreadCount}
+                    </span>
+                  )}
+                </Link>
                 {user.role === 'admin' && (
                   <Link to="/admin/jobs" className="font-medium text-slate-700 hover:text-slate-900">
                     Задачи парсинга

--- a/frontend/src/lib/listings.ts
+++ b/frontend/src/lib/listings.ts
@@ -25,6 +25,7 @@ export interface ListingOut {
   first_seen_at: string
   last_seen_at: string
   last_checked_at: string
+  is_following: boolean
 }
 
 export interface ListingSnapshotOut {
@@ -43,4 +44,6 @@ export interface ListingHistoryOut {
 export const listingsApi = {
   get: (id: string) => apiFetch<ListingOut>(`/api/v1/listings/${id}`),
   getHistory: (id: string) => apiFetch<ListingHistoryOut>(`/api/v1/listings/${id}/history`),
+  follow: (id: string) => apiFetch<void>(`/api/v1/listings/${id}/follow`, { method: 'POST' }),
+  unfollow: (id: string) => apiFetch<void>(`/api/v1/listings/${id}/follow`, { method: 'DELETE' }),
 }

--- a/frontend/src/lib/notifications.ts
+++ b/frontend/src/lib/notifications.ts
@@ -1,0 +1,22 @@
+import { apiFetch } from './client'
+
+export type NotificationType = 'new_match' | 'price_drop' | 'listing_removed' | 'market_change'
+
+export interface NotificationOut {
+  id: string
+  type: NotificationType
+  listing_id: string | null
+  payload: Record<string, unknown> | null
+  read_at: string | null
+  created_at: string
+}
+
+export interface NotificationListOut {
+  notifications: NotificationOut[]
+  unread_count: number
+}
+
+export const notificationsApi = {
+  list: () => apiFetch<NotificationListOut>('/api/v1/me/notifications'),
+  markRead: (id: string) => apiFetch<NotificationOut>(`/api/v1/me/notifications/${id}/read`, { method: 'POST' }),
+}

--- a/frontend/src/lib/savedSearches.ts
+++ b/frontend/src/lib/savedSearches.ts
@@ -14,6 +14,8 @@ export interface SavedSearchOut {
 export const savedSearchesApi = {
   list: () => apiFetch<SavedSearchOut[]>('/api/v1/saved-searches'),
 
+  get: (id: string) => apiFetch<SavedSearchOut>(`/api/v1/saved-searches/${id}`),
+
   create: (name: string, query: SearchQuery) =>
     apiFetch<SavedSearchOut>('/api/v1/saved-searches', {
       method: 'POST',

--- a/frontend/src/lib/savedSearches.ts
+++ b/frontend/src/lib/savedSearches.ts
@@ -1,0 +1,32 @@
+import { apiFetch } from './client'
+import type { SearchQuery, SearchResponse } from './search'
+
+export interface SavedSearchOut {
+  id: string
+  name: string
+  query: SearchQuery
+  enabled: boolean
+  notification_settings: Record<string, unknown> | null
+  last_run_at: string | null
+  created_at: string
+}
+
+export const savedSearchesApi = {
+  list: () => apiFetch<SavedSearchOut[]>('/api/v1/saved-searches'),
+
+  create: (name: string, query: SearchQuery) =>
+    apiFetch<SavedSearchOut>('/api/v1/saved-searches', {
+      method: 'POST',
+      body: JSON.stringify({ name, query }),
+    }),
+
+  update: (id: string, update: { name?: string; enabled?: boolean }) =>
+    apiFetch<SavedSearchOut>(`/api/v1/saved-searches/${id}`, {
+      method: 'PATCH',
+      body: JSON.stringify(update),
+    }),
+
+  remove: (id: string) => apiFetch<void>(`/api/v1/saved-searches/${id}`, { method: 'DELETE' }),
+
+  run: (id: string) => apiFetch<SearchResponse>(`/api/v1/saved-searches/${id}/run`, { method: 'POST' }),
+}

--- a/frontend/src/notifications/format.ts
+++ b/frontend/src/notifications/format.ts
@@ -30,8 +30,11 @@ export function notificationDescription(notification: NotificationOut): string {
   switch (notification.type) {
     case 'new_match': {
       const count = typeof payload.new_listings_count === 'number' ? payload.new_listings_count : 0
+      const updatedCount = typeof payload.updated_listings_count === 'number' ? payload.updated_listings_count : 0
       const description = typeof payload.query_description === 'string' ? payload.query_description : ''
-      return `${count} ${pluralizeListings(count)}${description ? ` — ${description}` : ''}`
+      const parts = [`${count} новых ${pluralizeListings(count)}`]
+      if (updatedCount > 0) parts.push(`${updatedCount} обновилось`)
+      return `${parts.join(', ')}${description ? ` — ${description}` : ''}`
     }
     case 'price_drop':
       return title

--- a/frontend/src/notifications/format.ts
+++ b/frontend/src/notifications/format.ts
@@ -1,13 +1,25 @@
 import type { NotificationOut } from '../lib/notifications'
 
 const TYPE_LABELS: Record<NotificationOut['type'], string> = {
-  new_match: 'Новое совпадение',
+  new_match: 'Новые объявления',
   price_drop: 'Цена снижена',
   listing_removed: 'Объявление снято',
   market_change: 'Изменение рынка',
 }
 
+// Mirrors app/notifications/delivery.py::_new_listings_phrase.
+function pluralizeListings(count: number): string {
+  if (count % 10 === 1 && count % 100 !== 11) return 'объявление'
+  if (count % 10 >= 2 && count % 10 <= 4 && !(count % 100 >= 12 && count % 100 <= 14)) return 'объявления'
+  return 'объявлений'
+}
+
 export function notificationTitle(notification: NotificationOut): string {
+  if (notification.type === 'new_match') {
+    const payload = notification.payload ?? {}
+    const name = typeof payload.saved_search_name === 'string' ? payload.saved_search_name : null
+    return name ? `«${name}»` : TYPE_LABELS.new_match
+  }
   return TYPE_LABELS[notification.type] ?? notification.type
 }
 
@@ -16,8 +28,11 @@ export function notificationDescription(notification: NotificationOut): string {
   const title = typeof payload.listing_title === 'string' ? payload.listing_title : null
 
   switch (notification.type) {
-    case 'new_match':
-      return title ? `${title} — ${payload.listing_price ?? ''} ${payload.currency ?? ''}`.trim() : 'Новое объявление'
+    case 'new_match': {
+      const count = typeof payload.new_listings_count === 'number' ? payload.new_listings_count : 0
+      const description = typeof payload.query_description === 'string' ? payload.query_description : ''
+      return `${count} ${pluralizeListings(count)}${description ? ` — ${description}` : ''}`
+    }
     case 'price_drop':
       return title
         ? `${title}: ${payload.previous_price ?? '?'} → ${payload.current_price ?? '?'} ${payload.currency ?? ''}`.trim()

--- a/frontend/src/notifications/format.ts
+++ b/frontend/src/notifications/format.ts
@@ -1,0 +1,32 @@
+import type { NotificationOut } from '../lib/notifications'
+
+const TYPE_LABELS: Record<NotificationOut['type'], string> = {
+  new_match: 'Новое совпадение',
+  price_drop: 'Цена снижена',
+  listing_removed: 'Объявление снято',
+  market_change: 'Изменение рынка',
+}
+
+export function notificationTitle(notification: NotificationOut): string {
+  return TYPE_LABELS[notification.type] ?? notification.type
+}
+
+export function notificationDescription(notification: NotificationOut): string {
+  const payload = notification.payload ?? {}
+  const title = typeof payload.listing_title === 'string' ? payload.listing_title : null
+
+  switch (notification.type) {
+    case 'new_match':
+      return title ? `${title} — ${payload.listing_price ?? ''} ${payload.currency ?? ''}`.trim() : 'Новое объявление'
+    case 'price_drop':
+      return title
+        ? `${title}: ${payload.previous_price ?? '?'} → ${payload.current_price ?? '?'} ${payload.currency ?? ''}`.trim()
+        : 'Цена снижена'
+    case 'listing_removed':
+      return title ? `${title} больше не доступно` : 'Объявление снято с публикации'
+    case 'market_change':
+      return typeof payload.description === 'string' ? payload.description : 'Изменение на рынке'
+    default:
+      return ''
+  }
+}

--- a/frontend/src/pages/ListingDetailPage.tsx
+++ b/frontend/src/pages/ListingDetailPage.tsx
@@ -1,5 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
+import { useState } from 'react'
 import { Link, useParams } from 'react-router-dom'
+import { useCurrentUser } from '../auth/useCurrentUser'
 import { ErrorState } from '../components/StateMessage'
 import { StatusBadge } from '../components/StatusBadge'
 import { ApiError } from '../lib/client'
@@ -27,12 +29,29 @@ function Field({ label, value }: { label: string; value: string }) {
 
 export function ListingDetailPage() {
   const { id } = useParams<{ id: string }>()
+  const { user } = useCurrentUser()
+  const [isTogglingFollow, setIsTogglingFollow] = useState(false)
 
   const query = useQuery({
     queryKey: ['listing-history', id],
     queryFn: () => listingsApi.getHistory(id!),
     enabled: Boolean(id),
   })
+
+  async function handleToggleFollow() {
+    if (!id || !query.data) return
+    setIsTogglingFollow(true)
+    try {
+      if (query.data.listing.is_following) {
+        await listingsApi.unfollow(id)
+      } else {
+        await listingsApi.follow(id)
+      }
+      await query.refetch()
+    } finally {
+      setIsTogglingFollow(false)
+    }
+  }
 
   if (query.isLoading) {
     return <div className="h-96 animate-pulse rounded-lg border border-slate-200 bg-slate-100" />
@@ -77,7 +96,23 @@ export function ListingDetailPage() {
           <div className="flex-1">
             <div className="flex items-start justify-between gap-3">
               <h1 className="text-lg font-semibold text-slate-900">{listing.title}</h1>
-              <StatusBadge status={listing.status} />
+              <div className="flex shrink-0 items-center gap-2">
+                <StatusBadge status={listing.status} />
+                {user && (
+                  <button
+                    type="button"
+                    onClick={handleToggleFollow}
+                    disabled={isTogglingFollow}
+                    className={
+                      listing.is_following
+                        ? 'rounded-md border border-slate-300 bg-slate-100 px-3 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-200 disabled:opacity-50'
+                        : 'rounded-md bg-slate-900 px-3 py-1.5 text-xs font-medium text-white hover:bg-slate-700 disabled:opacity-50'
+                    }
+                  >
+                    {listing.is_following ? 'Отслеживается ✓' : 'Отслеживать цену'}
+                  </button>
+                )}
+              </div>
             </div>
             <p className="mt-1 text-2xl font-bold text-slate-900">{formatPrice(listing.price, listing.currency)}</p>
 

--- a/frontend/src/pages/NotificationsPage.tsx
+++ b/frontend/src/pages/NotificationsPage.tsx
@@ -1,0 +1,66 @@
+import { useQuery } from '@tanstack/react-query'
+import { Link } from 'react-router-dom'
+import { EmptyState, ErrorState, LoadingState } from '../components/StateMessage'
+import { formatDate } from '../lib/format'
+import { notificationsApi } from '../lib/notifications'
+import { notificationDescription, notificationTitle } from '../notifications/format'
+
+export function NotificationsPage() {
+  const query = useQuery({ queryKey: ['notifications'], queryFn: notificationsApi.list })
+
+  async function handleRead(id: string) {
+    await notificationsApi.markRead(id)
+    await query.refetch()
+  }
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-xl font-semibold text-slate-900">Уведомления</h1>
+
+      {query.isLoading && <LoadingState />}
+      {query.isError && <ErrorState message="Не удалось загрузить уведомления" onRetry={() => query.refetch()} />}
+      {query.isSuccess && query.data.notifications.length === 0 && <EmptyState message="Уведомлений пока нет" />}
+
+      {query.isSuccess && query.data.notifications.length > 0 && (
+        <div className="divide-y divide-slate-100 rounded-lg border border-slate-200 bg-white">
+          {query.data.notifications.map((notification) => {
+            const content = (
+              <div className="flex items-start justify-between gap-3 px-4 py-3">
+                <div>
+                  <p className="text-sm font-medium text-slate-900">{notificationTitle(notification)}</p>
+                  <p className="mt-0.5 text-sm text-slate-600">{notificationDescription(notification)}</p>
+                  <p className="mt-1 text-xs text-slate-400">{formatDate(notification.created_at)}</p>
+                </div>
+                {!notification.read_at && (
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.preventDefault()
+                      handleRead(notification.id)
+                    }}
+                    className="shrink-0 rounded-full bg-slate-900 px-2 py-0.5 text-xs font-medium text-white hover:bg-slate-700"
+                  >
+                    Прочитано
+                  </button>
+                )}
+              </div>
+            )
+            return notification.listing_id ? (
+              <Link
+                key={notification.id}
+                to={`/listings/${notification.listing_id}`}
+                className={notification.read_at ? 'block hover:bg-slate-50' : 'block bg-slate-50 hover:bg-slate-100'}
+              >
+                {content}
+              </Link>
+            ) : (
+              <div key={notification.id} className={notification.read_at ? '' : 'bg-slate-50'}>
+                {content}
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/NotificationsPage.tsx
+++ b/frontend/src/pages/NotificationsPage.tsx
@@ -2,8 +2,17 @@ import { useQuery } from '@tanstack/react-query'
 import { Link } from 'react-router-dom'
 import { EmptyState, ErrorState, LoadingState } from '../components/StateMessage'
 import { formatDate } from '../lib/format'
+import type { NotificationOut } from '../lib/notifications'
 import { notificationsApi } from '../lib/notifications'
 import { notificationDescription, notificationTitle } from '../notifications/format'
+
+function notificationLinkTo(notification: NotificationOut): string | null {
+  if (notification.listing_id) return `/listings/${notification.listing_id}`
+  if (notification.type === 'new_match' && typeof notification.payload?.saved_search_id === 'string') {
+    return `/saved-searches/${notification.payload.saved_search_id}`
+  }
+  return null
+}
 
 export function NotificationsPage() {
   const query = useQuery({ queryKey: ['notifications'], queryFn: notificationsApi.list })
@@ -45,10 +54,11 @@ export function NotificationsPage() {
                 )}
               </div>
             )
-            return notification.listing_id ? (
+            const linkTo = notificationLinkTo(notification)
+            return linkTo ? (
               <Link
                 key={notification.id}
-                to={`/listings/${notification.listing_id}`}
+                to={linkTo}
                 className={notification.read_at ? 'block hover:bg-slate-50' : 'block bg-slate-50 hover:bg-slate-100'}
               >
                 {content}

--- a/frontend/src/pages/OpenSavedSearchPage.tsx
+++ b/frontend/src/pages/OpenSavedSearchPage.tsx
@@ -1,0 +1,37 @@
+import { useQuery } from '@tanstack/react-query'
+import { Navigate, useParams } from 'react-router-dom'
+import { ErrorState } from '../components/StateMessage'
+import { ApiError } from '../lib/client'
+import { savedSearchesApi } from '../lib/savedSearches'
+
+// Landing point for the "N new listings" email link (app/notifications/delivery.py) — loads the
+// saved search then hands its query off to SearchPage via router state, same as the "Открыть в
+// поиске" link on SavedSearchesPage.
+export function OpenSavedSearchPage() {
+  const { id } = useParams<{ id: string }>()
+
+  const query = useQuery({
+    queryKey: ['saved-search', id],
+    queryFn: () => savedSearchesApi.get(id!),
+    enabled: Boolean(id),
+  })
+
+  if (query.isLoading) {
+    return <div className="h-40 animate-pulse rounded-lg border border-slate-200 bg-slate-100" />
+  }
+
+  if (query.isError) {
+    return (
+      <ErrorState
+        message={
+          query.error instanceof ApiError && query.error.status === 404
+            ? 'Сохранённый поиск не найден'
+            : 'Не удалось открыть сохранённый поиск'
+        }
+        onRetry={() => query.refetch()}
+      />
+    )
+  }
+
+  return <Navigate to="/" state={{ savedQuery: query.data!.query }} replace />
+}

--- a/frontend/src/pages/SavedSearchesPage.tsx
+++ b/frontend/src/pages/SavedSearchesPage.tsx
@@ -1,0 +1,123 @@
+import { useQuery } from '@tanstack/react-query'
+import { useState } from 'react'
+import { Link } from 'react-router-dom'
+import { ApiError } from '../lib/client'
+import { formatDate } from '../lib/format'
+import type { SearchQuery } from '../lib/search'
+import { savedSearchesApi } from '../lib/savedSearches'
+import { EmptyState, ErrorState, LoadingState } from '../components/StateMessage'
+
+function describeQuery(query: SearchQuery): string {
+  const parts: string[] = []
+  if (query.make) parts.push(String(query.make))
+  if (Array.isArray(query.models) && query.models.length) parts.push((query.models as string[]).join('/'))
+  if (query.year_min || query.year_max) parts.push(`${query.year_min ?? '…'}–${query.year_max ?? '…'}`)
+  if (query.price_min || query.price_max) parts.push(`€${query.price_min ?? '…'}–${query.price_max ?? '…'}`)
+  return parts.length ? parts.join(', ') : 'Все объявления'
+}
+
+export function SavedSearchesPage() {
+  const [pendingId, setPendingId] = useState<string | null>(null)
+  const [actionError, setActionError] = useState<string | null>(null)
+
+  const query = useQuery({ queryKey: ['saved-searches'], queryFn: savedSearchesApi.list })
+
+  async function handleToggle(id: string, enabled: boolean) {
+    setPendingId(id)
+    setActionError(null)
+    try {
+      await savedSearchesApi.update(id, { enabled: !enabled })
+      await query.refetch()
+    } catch (err) {
+      setActionError(err instanceof ApiError ? err.message : 'Не удалось изменить сохранённый поиск')
+    } finally {
+      setPendingId(null)
+    }
+  }
+
+  async function handleDelete(id: string) {
+    setPendingId(id)
+    setActionError(null)
+    try {
+      await savedSearchesApi.remove(id)
+      await query.refetch()
+    } catch (err) {
+      setActionError(err instanceof ApiError ? err.message : 'Не удалось удалить сохранённый поиск')
+    } finally {
+      setPendingId(null)
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h1 className="text-xl font-semibold text-slate-900">Сохранённые поиски</h1>
+        <p className="mt-1 text-sm text-slate-600">
+          Каждый активный поиск автоматически обновляется, а о новых и подешевевших объявлениях приходит
+          уведомление.
+        </p>
+      </div>
+
+      {actionError && <p className="text-sm text-red-600">{actionError}</p>}
+
+      {query.isLoading && <LoadingState />}
+      {query.isError && <ErrorState message="Не удалось загрузить сохранённые поиски" onRetry={() => query.refetch()} />}
+      {query.isSuccess && query.data.length === 0 && (
+        <EmptyState message="Пока нет сохранённых поисков — сохраните текущие фильтры на странице поиска." />
+      )}
+
+      {query.isSuccess && query.data.length > 0 && (
+        <div className="overflow-x-auto rounded-lg border border-slate-200 bg-white">
+          <table className="w-full text-left text-sm">
+            <thead className="border-b border-slate-200 bg-slate-50 text-xs uppercase text-slate-500">
+              <tr>
+                <th className="px-4 py-2">Название</th>
+                <th className="px-4 py-2">Фильтры</th>
+                <th className="px-4 py-2">Статус</th>
+                <th className="px-4 py-2">Последний запуск</th>
+                <th className="px-4 py-2" />
+              </tr>
+            </thead>
+            <tbody>
+              {query.data.map((saved) => (
+                <tr key={saved.id} className="border-b border-slate-100 last:border-0">
+                  <td className="px-4 py-2 font-medium text-slate-900">{saved.name}</td>
+                  <td className="px-4 py-2 text-slate-600">{describeQuery(saved.query)}</td>
+                  <td className="px-4 py-2 text-slate-700">{saved.enabled ? 'активен' : 'приостановлен'}</td>
+                  <td className="px-4 py-2 text-slate-500">
+                    {saved.last_run_at ? formatDate(saved.last_run_at) : 'ещё не запускался'}
+                  </td>
+                  <td className="px-4 py-2 text-right">
+                    <Link
+                      to="/"
+                      state={{ savedQuery: saved.query }}
+                      className="text-xs font-medium text-slate-700 hover:underline"
+                    >
+                      Открыть в поиске
+                    </Link>
+                    <button
+                      type="button"
+                      disabled={pendingId === saved.id}
+                      onClick={() => handleToggle(saved.id, saved.enabled)}
+                      className="ml-3 rounded-md border border-slate-300 px-2 py-1 text-xs font-medium text-slate-700 hover:bg-slate-100 disabled:opacity-50"
+                    >
+                      {saved.enabled ? 'Приостановить' : 'Возобновить'}
+                    </button>
+                    <button
+                      type="button"
+                      disabled={pendingId === saved.id}
+                      onClick={() => handleDelete(saved.id)}
+                      className="ml-2 rounded-md border border-slate-300 px-2 py-1 text-xs font-medium text-slate-700 hover:bg-slate-100 disabled:opacity-50"
+                    >
+                      Удалить
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -1,6 +1,7 @@
 import { keepPreviousData, useQuery } from '@tanstack/react-query'
 import { useState } from 'react'
 import { useLocation } from 'react-router-dom'
+import { useCurrentUser } from '../auth/useCurrentUser'
 import { ListingCard } from '../components/ListingCard'
 import { Pagination } from '../components/Pagination'
 import { EmptyState, ErrorState, LoadingState } from '../components/StateMessage'
@@ -8,6 +9,7 @@ import { SuccessText } from '../components/AuthCard'
 import { ApiError } from '../lib/client'
 import type { GroupField, SearchQuery } from '../lib/search'
 import { DEFAULT_GROUP_BY, searchApi } from '../lib/search'
+import { savedSearchesApi } from '../lib/savedSearches'
 import { PAGE_SIZE } from '../search/constants'
 import { GroupCard } from '../search/GroupCard'
 import { SearchFilters } from '../search/SearchFilters'
@@ -15,10 +17,16 @@ import { ViewControls } from '../search/ViewControls'
 
 export function SearchPage() {
   const location = useLocation()
-  const justRegistered = Boolean((location.state as { justRegistered?: boolean } | null)?.justRegistered)
+  const state = location.state as { justRegistered?: boolean; savedQuery?: SearchQuery } | null
+  const justRegistered = Boolean(state?.justRegistered)
+  const { user } = useCurrentUser()
 
-  const [draftQuery, setDraftQuery] = useState<SearchQuery>({})
-  const [appliedQuery, setAppliedQuery] = useState<SearchQuery>({})
+  const [draftQuery, setDraftQuery] = useState<SearchQuery>(state?.savedQuery ?? {})
+  const [appliedQuery, setAppliedQuery] = useState<SearchQuery>(state?.savedQuery ?? {})
+  const [saveName, setSaveName] = useState('')
+  const [isSavingSearch, setIsSavingSearch] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
+  const [saveSuccess, setSaveSuccess] = useState(false)
   const [groupBy, setGroupBy] = useState<GroupField[]>(DEFAULT_GROUP_BY)
   const [minGroupCount, setMinGroupCount] = useState<number | null>(null)
   const [sort, setSort] = useState('count_desc')
@@ -53,6 +61,21 @@ export function SearchPage() {
   const total = isGrouped ? (query.data?.total_groups ?? 0) : (query.data?.total_listings ?? 0)
   const isEmpty = !query.isLoading && !query.isError && total === 0
 
+  async function handleSaveSearch(event: React.FormEvent) {
+    event.preventDefault()
+    setSaveError(null)
+    setIsSavingSearch(true)
+    try {
+      await savedSearchesApi.create(saveName, appliedQuery)
+      setSaveName('')
+      setSaveSuccess(true)
+    } catch (err) {
+      setSaveError(err instanceof ApiError ? err.message : 'Не удалось сохранить поиск')
+    } finally {
+      setIsSavingSearch(false)
+    }
+  }
+
   return (
     <div className="space-y-4">
       {justRegistered && (
@@ -66,8 +89,30 @@ export function SearchPage() {
         onSubmit={() => {
           setAppliedQuery(draftQuery)
           setPage(1)
+          setSaveSuccess(false)
         }}
       />
+
+      {user && (
+        <form onSubmit={handleSaveSearch} className="flex flex-wrap items-center gap-2 rounded-lg border border-slate-200 bg-white p-3">
+          <input
+            value={saveName}
+            onChange={(e) => setSaveName(e.target.value)}
+            placeholder="Название сохранённого поиска"
+            required
+            className="min-w-0 flex-1 rounded-md border border-slate-300 px-3 py-1.5 text-sm"
+          />
+          <button
+            type="submit"
+            disabled={isSavingSearch}
+            className="rounded-md border border-slate-300 px-3 py-1.5 text-sm font-medium text-slate-700 hover:bg-slate-100 disabled:opacity-50"
+          >
+            {isSavingSearch ? 'Сохраняем…' : 'Сохранить поиск с текущими фильтрами'}
+          </button>
+          {saveError && <span className="text-sm text-red-600">{saveError}</span>}
+          {saveSuccess && !saveError && <span className="text-sm text-emerald-600">Сохранено ✓</span>}
+        </form>
+      )}
 
       <ViewControls
         groupBy={groupBy}

--- a/migrations/versions/e5f6a7b8c9d0_add_follows.py
+++ b/migrations/versions/e5f6a7b8c9d0_add_follows.py
@@ -1,0 +1,41 @@
+"""add follows
+
+Revision ID: e5f6a7b8c9d0
+Revises: d4e5f6a7b8c9
+Create Date: 2026-09-10 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'e5f6a7b8c9d0'
+down_revision: Union[str, Sequence[str], None] = 'd4e5f6a7b8c9'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'follows',
+        sa.Column('user_id', sa.Uuid(), nullable=False),
+        sa.Column('listing_id', sa.Uuid(), nullable=False),
+        sa.Column('id', sa.Uuid(), nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('updated_at', sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(['listing_id'], ['listings.id'], name=op.f('fk_follows_listing_id_listings')),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id'], name=op.f('fk_follows_user_id_users')),
+        sa.PrimaryKeyConstraint('id', name=op.f('pk_follows')),
+        sa.UniqueConstraint('user_id', 'listing_id', name='uq_follows_user_id_listing_id'),
+    )
+    op.create_index(op.f('ix_follows_user_id'), 'follows', ['user_id'], unique=False)
+    op.create_index(op.f('ix_follows_listing_id'), 'follows', ['listing_id'], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f('ix_follows_listing_id'), table_name='follows')
+    op.drop_index(op.f('ix_follows_user_id'), table_name='follows')
+    op.drop_table('follows')

--- a/migrations/versions/f6a7b8c9d0e1_add_notification_listing_id.py
+++ b/migrations/versions/f6a7b8c9d0e1_add_notification_listing_id.py
@@ -1,0 +1,32 @@
+"""add notification listing_id
+
+Revision ID: f6a7b8c9d0e1
+Revises: e5f6a7b8c9d0
+Create Date: 2026-09-10 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'f6a7b8c9d0e1'
+down_revision: Union[str, Sequence[str], None] = 'e5f6a7b8c9d0'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('notifications', sa.Column('listing_id', sa.Uuid(), nullable=True))
+    op.create_foreign_key(
+        op.f('fk_notifications_listing_id_listings'), 'notifications', 'listings', ['listing_id'], ['id']
+    )
+    op.create_index(op.f('ix_notifications_listing_id'), 'notifications', ['listing_id'], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f('ix_notifications_listing_id'), table_name='notifications')
+    op.drop_constraint(op.f('fk_notifications_listing_id_listings'), 'notifications', type_='foreignkey')
+    op.drop_column('notifications', 'listing_id')

--- a/tests/unit/test_follow_endpoints.py
+++ b/tests/unit/test_follow_endpoints.py
@@ -1,0 +1,184 @@
+"""Endpoint-level tests for the listing follow API (#21), following
+tests/unit/test_scrape_endpoints.py's pattern.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+import pytest_asyncio
+from fakeredis import FakeAsyncRedis
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.auth.email import get_email_sender
+from app.config import get_settings
+from app.db.base import Base
+from app.db.session import get_session
+from app.infrastructure.redis import get_redis
+from app.main import app
+from app.models.listing import Listing, ListingStatus
+from app.models.source import Source
+
+
+class RecordingEmailSender:
+    def __init__(self):
+        self.sent = []
+
+    async def send(self, to: str, subject: str, body: str) -> None:
+        self.sent.append({"to": to, "subject": subject, "body": body})
+
+    def last_token(self) -> str:
+        return self.sent[-1]["body"].rsplit("token=", 1)[-1]
+
+
+@pytest.fixture
+def email_sender():
+    return RecordingEmailSender()
+
+
+@pytest_asyncio.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:", poolclass=StaticPool, connect_args={"check_same_thread": False}
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    yield factory
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def client(session_factory, email_sender):
+    async def override_get_session():
+        async with session_factory() as session:
+            yield session
+
+    fake_redis = FakeAsyncRedis(decode_responses=True)
+
+    app.dependency_overrides[get_session] = override_get_session
+    app.dependency_overrides[get_redis] = lambda: fake_redis
+    app.dependency_overrides[get_email_sender] = lambda: email_sender
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as async_client:
+        yield async_client
+
+    app.dependency_overrides.clear()
+    await fake_redis.aclose()
+
+
+def _csrf_headers(client: AsyncClient) -> dict[str, str]:
+    settings = get_settings()
+    return {settings.csrf_header_name: client.cookies[settings.csrf_cookie_name]}
+
+
+async def _register_and_login(
+    client: AsyncClient, email_sender: RecordingEmailSender, email: str = "follower@example.com"
+) -> None:
+    await client.post("/api/v1/auth/register", json={"email": email, "password": "hunter2pass"})
+    token = email_sender.last_token()
+    await client.post("/api/v1/auth/verify-email", json={"token": token})
+    await client.post("/api/v1/auth/login", json={"email": email, "password": "hunter2pass"})
+
+
+async def _seed_listing(session_factory) -> str:
+    now = datetime.now(timezone.utc)
+    async with session_factory() as session:
+        source = Source(code="polovniautomobili", name="Polovni Automobili", domain="x.rs", country="RS")
+        session.add(source)
+        await session.flush()
+        listing = Listing(
+            source_id=source.id,
+            external_id="1",
+            canonical_url="https://x.rs/1",
+            title="Skoda Octavia",
+            make="Skoda",
+            model="Octavia",
+            production_year=2019,
+            mileage_km=100_000,
+            price=10_000,
+            currency="EUR",
+            status=ListingStatus.ACTIVE,
+            first_seen_at=now,
+            last_seen_at=now,
+            last_checked_at=now,
+        )
+        session.add(listing)
+        await session.commit()
+        return str(listing.id)
+
+
+async def test_get_listing_without_auth_has_is_following_false(client, session_factory):
+    listing_id = await _seed_listing(session_factory)
+    response = await client.get(f"/api/v1/listings/{listing_id}")
+    assert response.status_code == 200
+    assert response.json()["is_following"] is False
+
+
+async def test_follow_then_get_listing_reflects_is_following(client, email_sender, session_factory):
+    listing_id = await _seed_listing(session_factory)
+    await _register_and_login(client, email_sender)
+
+    follow_response = await client.post(f"/api/v1/listings/{listing_id}/follow", headers=_csrf_headers(client))
+    assert follow_response.status_code == 204
+
+    response = await client.get(f"/api/v1/listings/{listing_id}")
+    assert response.json()["is_following"] is True
+
+
+async def test_follow_then_get_listing_history_reflects_is_following(client, email_sender, session_factory):
+    # ListingDetailPage.tsx renders off /history, not the plain listing GET — both must carry
+    # is_following, not just one of them.
+    listing_id = await _seed_listing(session_factory)
+    await _register_and_login(client, email_sender)
+
+    await client.post(f"/api/v1/listings/{listing_id}/follow", headers=_csrf_headers(client))
+
+    response = await client.get(f"/api/v1/listings/{listing_id}/history")
+    assert response.json()["listing"]["is_following"] is True
+
+
+async def test_follow_is_idempotent(client, email_sender, session_factory):
+    listing_id = await _seed_listing(session_factory)
+    await _register_and_login(client, email_sender)
+
+    first = await client.post(f"/api/v1/listings/{listing_id}/follow", headers=_csrf_headers(client))
+    second = await client.post(f"/api/v1/listings/{listing_id}/follow", headers=_csrf_headers(client))
+    assert first.status_code == 204
+    assert second.status_code == 204
+
+
+async def test_unfollow_removes_follow(client, email_sender, session_factory):
+    listing_id = await _seed_listing(session_factory)
+    await _register_and_login(client, email_sender)
+    await client.post(f"/api/v1/listings/{listing_id}/follow", headers=_csrf_headers(client))
+
+    response = await client.delete(f"/api/v1/listings/{listing_id}/follow", headers=_csrf_headers(client))
+    assert response.status_code == 204
+
+    get_response = await client.get(f"/api/v1/listings/{listing_id}")
+    assert get_response.json()["is_following"] is False
+
+
+async def test_unfollow_without_existing_follow_is_a_noop(client, email_sender, session_factory):
+    listing_id = await _seed_listing(session_factory)
+    await _register_and_login(client, email_sender)
+
+    response = await client.delete(f"/api/v1/listings/{listing_id}/follow", headers=_csrf_headers(client))
+    assert response.status_code == 204
+
+
+async def test_follow_requires_auth(client, session_factory):
+    listing_id = await _seed_listing(session_factory)
+    response = await client.post(f"/api/v1/listings/{listing_id}/follow")
+    assert response.status_code == 401
+
+
+async def test_follow_unknown_listing_404s(client, email_sender):
+    await _register_and_login(client, email_sender)
+    response = await client.post(
+        "/api/v1/listings/00000000-0000-0000-0000-000000000000/follow", headers=_csrf_headers(client)
+    )
+    assert response.status_code == 404

--- a/tests/unit/test_notification_delivery.py
+++ b/tests/unit/test_notification_delivery.py
@@ -33,17 +33,45 @@ class RecordingEmailSender:
 def test_render_new_match():
     notification = Notification(
         type=NotificationType.NEW_MATCH,
-        payload={"listing_title": "Skoda Octavia", "listing_price": 10_000, "currency": "EUR"},
+        payload={
+            "saved_search_id": "11111111-1111-1111-1111-111111111111",
+            "saved_search_name": "Skoda всех годов",
+            "new_listings_count": 3,
+            "query_description": "Skoda",
+        },
     )
     subject, body = render_notification(notification)
-    assert "Skoda Octavia" in subject
-    assert "10000" in body or "10_000" in body
+    assert "Skoda всех годов" in subject
+    assert "3" in subject
+    assert "Skoda всех годов" in body
+    assert "Skoda" in body  # query_description
+    assert "/saved-searches/11111111-1111-1111-1111-111111111111" in body
+
+
+def test_render_new_match_agrees_singular_plural_forms():
+    def subject_for(count: int) -> str:
+        notification = Notification(
+            type=NotificationType.NEW_MATCH,
+            payload={"saved_search_name": "X", "new_listings_count": count, "query_description": ""},
+        )
+        return render_notification(notification)[0]
+
+    assert "1 новое объявление" in subject_for(1)
+    assert "2 новых объявления" in subject_for(2)
+    assert "5 новых объявлений" in subject_for(5)
+    assert "11 новых объявлений" in subject_for(11)
+    assert "21 новое объявление" in subject_for(21)
 
 
 def test_render_price_drop_shows_before_and_after():
     notification = Notification(
         type=NotificationType.PRICE_DROP,
-        payload={"listing_title": "Skoda Octavia", "previous_price": 12_000, "current_price": 10_000, "currency": "EUR"},
+        payload={
+            "listing_title": "Skoda Octavia",
+            "previous_price": 12_000,
+            "current_price": 10_000,
+            "currency": "EUR",
+        },
     )
     subject, body = render_notification(notification)
     assert "Skoda Octavia" in subject
@@ -57,7 +85,9 @@ async def test_send_notification_email_delivers_to_owning_user(session_factory):
         session.add(user)
         await session.flush()
         notification = Notification(
-            user_id=user.id, type=NotificationType.NEW_MATCH, payload={"listing_title": "Skoda"}
+            user_id=user.id,
+            type=NotificationType.NEW_MATCH,
+            payload={"saved_search_name": "Skoda", "new_listings_count": 1, "query_description": "Skoda"},
         )
         session.add(notification)
         await session.commit()

--- a/tests/unit/test_notification_delivery.py
+++ b/tests/unit/test_notification_delivery.py
@@ -1,0 +1,82 @@
+import uuid
+
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.db.base import Base
+from app.models.notification import Notification, NotificationType
+from app.models.user import User
+from app.notifications.delivery import render_notification, send_notification_email
+
+
+@pytest_asyncio.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:", poolclass=StaticPool, connect_args={"check_same_thread": False}
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    yield factory
+    await engine.dispose()
+
+
+class RecordingEmailSender:
+    def __init__(self):
+        self.sent = []
+
+    async def send(self, to: str, subject: str, body: str) -> None:
+        self.sent.append({"to": to, "subject": subject, "body": body})
+
+
+def test_render_new_match():
+    notification = Notification(
+        type=NotificationType.NEW_MATCH,
+        payload={"listing_title": "Skoda Octavia", "listing_price": 10_000, "currency": "EUR"},
+    )
+    subject, body = render_notification(notification)
+    assert "Skoda Octavia" in subject
+    assert "10000" in body or "10_000" in body
+
+
+def test_render_price_drop_shows_before_and_after():
+    notification = Notification(
+        type=NotificationType.PRICE_DROP,
+        payload={"listing_title": "Skoda Octavia", "previous_price": 12_000, "current_price": 10_000, "currency": "EUR"},
+    )
+    subject, body = render_notification(notification)
+    assert "Skoda Octavia" in subject
+    assert "12000" in body
+    assert "10000" in body
+
+
+async def test_send_notification_email_delivers_to_owning_user(session_factory):
+    async with session_factory() as session:
+        user = User(email="target@example.com", password_hash="x")
+        session.add(user)
+        await session.flush()
+        notification = Notification(
+            user_id=user.id, type=NotificationType.NEW_MATCH, payload={"listing_title": "Skoda"}
+        )
+        session.add(notification)
+        await session.commit()
+        notification_id = str(notification.id)
+
+    email_sender = RecordingEmailSender()
+    ctx = {"session_factory": session_factory, "email_sender": email_sender}
+
+    await send_notification_email(ctx, notification_id)
+
+    assert len(email_sender.sent) == 1
+    assert email_sender.sent[0]["to"] == "target@example.com"
+    assert "Skoda" in email_sender.sent[0]["subject"]
+
+
+async def test_send_notification_email_skips_unknown_notification(session_factory):
+    email_sender = RecordingEmailSender()
+    ctx = {"session_factory": session_factory, "email_sender": email_sender}
+
+    await send_notification_email(ctx, str(uuid.uuid4()))
+
+    assert email_sender.sent == []

--- a/tests/unit/test_notification_delivery.py
+++ b/tests/unit/test_notification_delivery.py
@@ -63,6 +63,47 @@ def test_render_new_match_agrees_singular_plural_forms():
     assert "21 новое объявление" in subject_for(21)
 
 
+def test_render_new_match_includes_updated_count_in_body():
+    notification = Notification(
+        type=NotificationType.NEW_MATCH,
+        payload={
+            "saved_search_name": "Skoda всех годов",
+            "new_listings_count": 2,
+            "updated_listings_count": 5,
+            "query_description": "Skoda",
+        },
+    )
+    subject, body = render_notification(notification)
+    assert "2 новых объявления" in subject
+    assert "Новых объявлений: 2" in body
+    assert "Обновлено объявлений: 5" in body
+
+
+def test_render_new_match_with_only_updates_no_new_listings():
+    notification = Notification(
+        type=NotificationType.NEW_MATCH,
+        payload={
+            "saved_search_name": "Skoda всех годов",
+            "new_listings_count": 0,
+            "updated_listings_count": 4,
+            "query_description": "Skoda",
+        },
+    )
+    subject, body = render_notification(notification)
+    assert "обновлено 4 объявления" in subject
+    assert "Новых объявлений: 0" in body
+    assert "Обновлено объявлений: 4" in body
+
+
+def test_render_new_match_omits_updated_line_when_nothing_updated():
+    notification = Notification(
+        type=NotificationType.NEW_MATCH,
+        payload={"saved_search_name": "X", "new_listings_count": 1, "query_description": ""},
+    )
+    _, body = render_notification(notification)
+    assert "Обновлено" not in body
+
+
 def test_render_price_drop_shows_before_and_after():
     notification = Notification(
         type=NotificationType.PRICE_DROP,

--- a/tests/unit/test_notification_endpoints.py
+++ b/tests/unit/test_notification_endpoints.py
@@ -1,0 +1,144 @@
+"""Endpoint-level tests for the in-app notification API (#23)."""
+
+import pytest
+import pytest_asyncio
+from fakeredis import FakeAsyncRedis
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.auth.email import get_email_sender
+from app.auth.repository import UserRepository
+from app.config import get_settings
+from app.db.base import Base
+from app.db.session import get_session
+from app.infrastructure.redis import get_redis
+from app.main import app
+from app.models.notification import Notification, NotificationType
+
+
+class RecordingEmailSender:
+    def __init__(self):
+        self.sent = []
+
+    async def send(self, to: str, subject: str, body: str) -> None:
+        self.sent.append({"to": to, "subject": subject, "body": body})
+
+    def last_token(self) -> str:
+        return self.sent[-1]["body"].rsplit("token=", 1)[-1]
+
+
+@pytest.fixture
+def email_sender():
+    return RecordingEmailSender()
+
+
+@pytest_asyncio.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:", poolclass=StaticPool, connect_args={"check_same_thread": False}
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    yield factory
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def client(session_factory, email_sender):
+    async def override_get_session():
+        async with session_factory() as session:
+            yield session
+
+    fake_redis = FakeAsyncRedis(decode_responses=True)
+
+    app.dependency_overrides[get_session] = override_get_session
+    app.dependency_overrides[get_redis] = lambda: fake_redis
+    app.dependency_overrides[get_email_sender] = lambda: email_sender
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as async_client:
+        yield async_client
+
+    app.dependency_overrides.clear()
+    await fake_redis.aclose()
+
+
+def _csrf_headers(client: AsyncClient) -> dict[str, str]:
+    settings = get_settings()
+    return {settings.csrf_header_name: client.cookies[settings.csrf_cookie_name]}
+
+
+async def _register_and_login(
+    client: AsyncClient, email_sender: RecordingEmailSender, email: str = "notified@example.com"
+) -> None:
+    await client.post("/api/v1/auth/register", json={"email": email, "password": "hunter2pass"})
+    token = email_sender.last_token()
+    await client.post("/api/v1/auth/verify-email", json={"token": token})
+    await client.post("/api/v1/auth/login", json={"email": email, "password": "hunter2pass"})
+
+
+async def _seed_notification(session_factory, email: str, **overrides) -> str:
+    async with session_factory() as session:
+        user = await UserRepository(session).get_by_email(email)
+        defaults = dict(user_id=user.id, type=NotificationType.NEW_MATCH, payload={"listing_title": "Skoda Octavia"})
+        defaults.update(overrides)
+        notification = Notification(**defaults)
+        session.add(notification)
+        await session.commit()
+        return str(notification.id)
+
+
+async def test_list_notifications_returns_own_with_unread_count(client, email_sender, session_factory):
+    await _register_and_login(client, email_sender)
+    await _seed_notification(session_factory, "notified@example.com")
+    await _seed_notification(session_factory, "notified@example.com")
+
+    response = await client.get("/api/v1/me/notifications")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["notifications"]) == 2
+    assert body["unread_count"] == 2
+
+
+async def test_list_notifications_requires_auth(client):
+    response = await client.get("/api/v1/me/notifications")
+    assert response.status_code == 401
+
+
+async def test_list_notifications_only_returns_own(client, email_sender, session_factory):
+    await _register_and_login(client, email_sender, email="alice@example.com")
+    await _seed_notification(session_factory, "alice@example.com")
+    await client.post("/api/v1/auth/logout")
+
+    await _register_and_login(client, email_sender, email="bob@example.com")
+    response = await client.get("/api/v1/me/notifications")
+
+    assert response.status_code == 200
+    assert response.json()["notifications"] == []
+
+
+async def test_mark_notification_read(client, email_sender, session_factory):
+    await _register_and_login(client, email_sender)
+    notification_id = await _seed_notification(session_factory, "notified@example.com")
+
+    response = await client.post(f"/api/v1/me/notifications/{notification_id}/read", headers=_csrf_headers(client))
+
+    assert response.status_code == 200
+    assert response.json()["read_at"] is not None
+
+    list_response = await client.get("/api/v1/me/notifications")
+    assert list_response.json()["unread_count"] == 0
+
+
+async def test_mark_notification_read_404_for_other_users_notification(client, email_sender, session_factory):
+    await _register_and_login(client, email_sender, email="alice@example.com")
+    notification_id = await _seed_notification(session_factory, "alice@example.com")
+    await client.post("/api/v1/auth/logout")
+
+    await _register_and_login(client, email_sender, email="bob@example.com")
+    response = await client.post(f"/api/v1/me/notifications/{notification_id}/read", headers=_csrf_headers(client))
+
+    assert response.status_code == 404

--- a/tests/unit/test_notification_matching.py
+++ b/tests/unit/test_notification_matching.py
@@ -31,14 +31,18 @@ async def session_factory():
     await engine.dispose()
 
 
-async def _seed_source_and_listing(session, **overrides) -> tuple[uuid.UUID, uuid.UUID]:
-    source = Source(code="polovniautomobili", name="Polovni Automobili", domain="x.rs", country="RS")
-    session.add(source)
-    await session.flush()
+async def _seed_source_and_listing(
+    session, source_id: uuid.UUID | None = None, **overrides
+) -> tuple[uuid.UUID, uuid.UUID]:
+    if source_id is None:
+        source = Source(code="polovniautomobili", name="Polovni Automobili", domain="x.rs", country="RS")
+        session.add(source)
+        await session.flush()
+        source_id = source.id
 
     now = datetime.now(timezone.utc)
     defaults = dict(
-        source_id=source.id,
+        source_id=source_id,
         external_id="1",
         canonical_url="https://x.rs/1",
         title="Skoda Octavia",
@@ -57,7 +61,7 @@ async def _seed_source_and_listing(session, **overrides) -> tuple[uuid.UUID, uui
     listing = Listing(**defaults)
     session.add(listing)
     await session.flush()
-    return source.id, listing.id
+    return source_id, listing.id
 
 
 async def test_price_drop_notifies_followers(session_factory):
@@ -119,7 +123,35 @@ async def test_new_match_notifies_owner_of_matching_saved_search(session_factory
         assert len(notifications) == 1
         assert notifications[0].user_id == user_id
         assert notifications[0].type == NotificationType.NEW_MATCH
+        assert notifications[0].listing_id is None
         assert notifications[0].payload["saved_search_name"] == "Skoda alert"
+        assert notifications[0].payload["new_listings_count"] == 1
+        assert notifications[0].payload["query_description"] == "Skoda"
+
+
+async def test_new_match_creates_one_aggregated_notification_for_multiple_new_listings(session_factory):
+    async with session_factory() as session:
+        source_id, listing_id_1 = await _seed_source_and_listing(session, external_id="1")
+        _, listing_id_2 = await _seed_source_and_listing(session, source_id=source_id, external_id="2")
+        user_id = uuid.uuid4()
+        query = SearchQuery(make="Skoda")
+        session.add(SavedSearch(user_id=user_id, name="Skoda alert", query=query.model_dump(), enabled=True))
+        job = ScrapeJob(
+            source_id=source_id,
+            job_type=ScrapeJobType.SAVED_SEARCH_REFRESH,
+            status=ScrapeJobStatus.RUNNING,
+            query=encode_job_query(query, max_pages=5),
+        )
+        session.add(job)
+        await session.commit()
+
+        stats = ScrapeStats(new_listing_ids=[listing_id_1, listing_id_2])
+        await generate_notifications_for_job(session, job, stats)
+        await session.commit()
+
+        notifications = (await session.execute(select(Notification))).scalars().all()
+        assert len(notifications) == 1
+        assert notifications[0].payload["new_listings_count"] == 2
 
 
 async def test_new_match_ignores_non_matching_saved_search(session_factory):

--- a/tests/unit/test_notification_matching.py
+++ b/tests/unit/test_notification_matching.py
@@ -154,6 +154,57 @@ async def test_new_match_creates_one_aggregated_notification_for_multiple_new_li
         assert notifications[0].payload["new_listings_count"] == 2
 
 
+async def test_new_match_includes_updated_count(session_factory):
+    async with session_factory() as session:
+        source_id, listing_id = await _seed_source_and_listing(session)
+        user_id = uuid.uuid4()
+        query = SearchQuery(make="Skoda")
+        session.add(SavedSearch(user_id=user_id, name="Skoda alert", query=query.model_dump(), enabled=True))
+        job = ScrapeJob(
+            source_id=source_id,
+            job_type=ScrapeJobType.SAVED_SEARCH_REFRESH,
+            status=ScrapeJobStatus.RUNNING,
+            query=encode_job_query(query, max_pages=5),
+        )
+        session.add(job)
+        await session.commit()
+
+        stats = ScrapeStats(new_listing_ids=[listing_id], listings_updated=3)
+        await generate_notifications_for_job(session, job, stats)
+        await session.commit()
+
+        notifications = (await session.execute(select(Notification))).scalars().all()
+        assert len(notifications) == 1
+        assert notifications[0].payload["new_listings_count"] == 1
+        assert notifications[0].payload["updated_listings_count"] == 3
+
+
+async def test_new_match_fires_on_updates_alone(session_factory):
+    async with session_factory() as session:
+        source_id, _ = await _seed_source_and_listing(session)
+        user_id = uuid.uuid4()
+        query = SearchQuery(make="Skoda")
+        session.add(SavedSearch(user_id=user_id, name="Skoda alert", query=query.model_dump(), enabled=True))
+        job = ScrapeJob(
+            source_id=source_id,
+            job_type=ScrapeJobType.SAVED_SEARCH_REFRESH,
+            status=ScrapeJobStatus.RUNNING,
+            query=encode_job_query(query, max_pages=5),
+        )
+        session.add(job)
+        await session.commit()
+
+        # No new_listing_ids at all — only existing listings changed price/mileage/title.
+        stats = ScrapeStats(listings_updated=2)
+        await generate_notifications_for_job(session, job, stats)
+        await session.commit()
+
+        notifications = (await session.execute(select(Notification))).scalars().all()
+        assert len(notifications) == 1
+        assert notifications[0].payload["new_listings_count"] == 0
+        assert notifications[0].payload["updated_listings_count"] == 2
+
+
 async def test_new_match_ignores_non_matching_saved_search(session_factory):
     async with session_factory() as session:
         source_id, listing_id = await _seed_source_and_listing(session)

--- a/tests/unit/test_notification_matching.py
+++ b/tests/unit/test_notification_matching.py
@@ -1,0 +1,194 @@
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.db.base import Base
+from app.models.follow import Follow
+from app.models.listing import Listing, ListingStatus
+from app.models.notification import Notification, NotificationType
+from app.models.saved_search import SavedSearch
+from app.models.scrape_job import ScrapeJob, ScrapeJobStatus, ScrapeJobType
+from app.models.source import Source
+from app.notifications.matching import generate_notifications_for_job
+from app.scraping.pipeline import ScrapeStats
+from app.scraping.schemas import encode_job_query
+from app.search.query import SearchQuery
+
+
+@pytest.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:", poolclass=StaticPool, connect_args={"check_same_thread": False}
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    yield factory
+    await engine.dispose()
+
+
+async def _seed_source_and_listing(session, **overrides) -> tuple[uuid.UUID, uuid.UUID]:
+    source = Source(code="polovniautomobili", name="Polovni Automobili", domain="x.rs", country="RS")
+    session.add(source)
+    await session.flush()
+
+    now = datetime.now(timezone.utc)
+    defaults = dict(
+        source_id=source.id,
+        external_id="1",
+        canonical_url="https://x.rs/1",
+        title="Skoda Octavia",
+        make="Skoda",
+        model="Octavia",
+        production_year=2019,
+        mileage_km=100_000,
+        price=10_000,
+        currency="EUR",
+        status=ListingStatus.ACTIVE,
+        first_seen_at=now,
+        last_seen_at=now,
+        last_checked_at=now,
+    )
+    defaults.update(overrides)
+    listing = Listing(**defaults)
+    session.add(listing)
+    await session.flush()
+    return source.id, listing.id
+
+
+async def test_price_drop_notifies_followers(session_factory):
+    async with session_factory() as session:
+        _, listing_id = await _seed_source_and_listing(session)
+        follower_id = uuid.uuid4()
+        session.add(Follow(user_id=follower_id, listing_id=listing_id))
+        job = ScrapeJob(source_id=uuid.uuid4(), job_type=ScrapeJobType.SEARCH, status=ScrapeJobStatus.RUNNING)
+        session.add(job)
+        await session.commit()
+
+        stats = ScrapeStats(price_drops=[(listing_id, 12_000, 10_000)])
+        await generate_notifications_for_job(session, job, stats)
+        await session.commit()
+
+        notifications = (await session.execute(select(Notification))).scalars().all()
+        assert len(notifications) == 1
+        assert notifications[0].user_id == follower_id
+        assert notifications[0].type == NotificationType.PRICE_DROP
+        assert notifications[0].payload["previous_price"] == 12_000
+        assert notifications[0].payload["current_price"] == 10_000
+
+
+async def test_price_drop_without_followers_creates_nothing(session_factory):
+    async with session_factory() as session:
+        _, listing_id = await _seed_source_and_listing(session)
+        job = ScrapeJob(source_id=uuid.uuid4(), job_type=ScrapeJobType.SEARCH, status=ScrapeJobStatus.RUNNING)
+        session.add(job)
+        await session.commit()
+
+        stats = ScrapeStats(price_drops=[(listing_id, 12_000, 10_000)])
+        await generate_notifications_for_job(session, job, stats)
+        await session.commit()
+
+        notifications = (await session.execute(select(Notification))).scalars().all()
+        assert notifications == []
+
+
+async def test_new_match_notifies_owner_of_matching_saved_search(session_factory):
+    async with session_factory() as session:
+        source_id, listing_id = await _seed_source_and_listing(session)
+        user_id = uuid.uuid4()
+        query = SearchQuery(make="Skoda")
+        session.add(SavedSearch(user_id=user_id, name="Skoda alert", query=query.model_dump(), enabled=True))
+        job = ScrapeJob(
+            source_id=source_id,
+            job_type=ScrapeJobType.SAVED_SEARCH_REFRESH,
+            status=ScrapeJobStatus.RUNNING,
+            query=encode_job_query(query, max_pages=5),
+        )
+        session.add(job)
+        await session.commit()
+
+        stats = ScrapeStats(new_listing_ids=[listing_id])
+        await generate_notifications_for_job(session, job, stats)
+        await session.commit()
+
+        notifications = (await session.execute(select(Notification))).scalars().all()
+        assert len(notifications) == 1
+        assert notifications[0].user_id == user_id
+        assert notifications[0].type == NotificationType.NEW_MATCH
+        assert notifications[0].payload["saved_search_name"] == "Skoda alert"
+
+
+async def test_new_match_ignores_non_matching_saved_search(session_factory):
+    async with session_factory() as session:
+        source_id, listing_id = await _seed_source_and_listing(session)
+        session.add(
+            SavedSearch(
+                user_id=uuid.uuid4(),
+                name="Audi alert",
+                query=SearchQuery(make="Audi").model_dump(),
+                enabled=True,
+            )
+        )
+        job_query = SearchQuery(make="Skoda")
+        job = ScrapeJob(
+            source_id=source_id,
+            job_type=ScrapeJobType.SAVED_SEARCH_REFRESH,
+            status=ScrapeJobStatus.RUNNING,
+            query=encode_job_query(job_query, max_pages=5),
+        )
+        session.add(job)
+        await session.commit()
+
+        stats = ScrapeStats(new_listing_ids=[listing_id])
+        await generate_notifications_for_job(session, job, stats)
+        await session.commit()
+
+        notifications = (await session.execute(select(Notification))).scalars().all()
+        assert notifications == []
+
+
+async def test_new_match_ignores_disabled_saved_search(session_factory):
+    async with session_factory() as session:
+        source_id, listing_id = await _seed_source_and_listing(session)
+        query = SearchQuery(make="Skoda")
+        session.add(SavedSearch(user_id=uuid.uuid4(), name="Skoda alert", query=query.model_dump(), enabled=False))
+        job = ScrapeJob(
+            source_id=source_id,
+            job_type=ScrapeJobType.SAVED_SEARCH_REFRESH,
+            status=ScrapeJobStatus.RUNNING,
+            query=encode_job_query(query, max_pages=5),
+        )
+        session.add(job)
+        await session.commit()
+
+        stats = ScrapeStats(new_listing_ids=[listing_id])
+        await generate_notifications_for_job(session, job, stats)
+        await session.commit()
+
+        notifications = (await session.execute(select(Notification))).scalars().all()
+        assert notifications == []
+
+
+async def test_generate_notifications_enqueues_email(session_factory):
+    async with session_factory() as session:
+        _, listing_id = await _seed_source_and_listing(session)
+        follower_id = uuid.uuid4()
+        session.add(Follow(user_id=follower_id, listing_id=listing_id))
+        job = ScrapeJob(source_id=uuid.uuid4(), job_type=ScrapeJobType.SEARCH, status=ScrapeJobStatus.RUNNING)
+        session.add(job)
+        await session.commit()
+
+        enqueued = []
+
+        async def enqueue_email(notification_id: str) -> None:
+            enqueued.append(notification_id)
+
+        stats = ScrapeStats(price_drops=[(listing_id, 12_000, 10_000)])
+        await generate_notifications_for_job(session, job, stats, enqueue_email=enqueue_email)
+        await session.commit()
+
+        assert len(enqueued) == 1

--- a/tests/unit/test_notification_service.py
+++ b/tests/unit/test_notification_service.py
@@ -1,0 +1,86 @@
+import uuid
+from datetime import timedelta
+
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from app.db.base import Base
+from app.models.notification import NotificationType
+from app.notifications.service import NotificationService
+
+
+@pytest_asyncio.fixture
+async def session():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with factory() as s:
+        yield s
+    await engine.dispose()
+
+
+async def test_notify_creates_notification_and_enqueues_email(session):
+    enqueued = []
+
+    async def enqueue_email(notification_id: str) -> None:
+        enqueued.append(notification_id)
+
+    service = NotificationService(session, enqueue_email=enqueue_email)
+    user_id = uuid.uuid4()
+
+    notification = await service.notify(user_id, NotificationType.NEW_MATCH, {"listing_title": "Skoda"})
+
+    assert notification is not None
+    assert notification.user_id == user_id
+    assert enqueued == [str(notification.id)]
+
+
+async def test_notify_without_enqueue_email_still_creates_notification(session):
+    service = NotificationService(session)
+    notification = await service.notify(uuid.uuid4(), NotificationType.LISTING_REMOVED, {})
+    assert notification is not None
+
+
+async def test_notify_skips_duplicate_within_cooldown(session):
+    service = NotificationService(session)
+    user_id = uuid.uuid4()
+    listing_id = uuid.uuid4()
+
+    first = await service.notify(
+        user_id, NotificationType.PRICE_DROP, {"previous_price": 100}, listing_id=listing_id
+    )
+    second = await service.notify(
+        user_id, NotificationType.PRICE_DROP, {"previous_price": 90}, listing_id=listing_id
+    )
+
+    assert first is not None
+    assert second is None
+
+
+async def test_notify_allows_duplicate_outside_cooldown(session):
+    service = NotificationService(session)
+    user_id = uuid.uuid4()
+    listing_id = uuid.uuid4()
+
+    first = await service.notify(
+        user_id, NotificationType.PRICE_DROP, {}, listing_id=listing_id, cooldown=timedelta(seconds=0)
+    )
+    second = await service.notify(
+        user_id, NotificationType.PRICE_DROP, {}, listing_id=listing_id, cooldown=timedelta(seconds=0)
+    )
+
+    assert first is not None
+    assert second is not None
+
+
+async def test_notify_does_not_dedup_across_different_types(session):
+    service = NotificationService(session)
+    user_id = uuid.uuid4()
+    listing_id = uuid.uuid4()
+
+    new_match = await service.notify(user_id, NotificationType.NEW_MATCH, {}, listing_id=listing_id)
+    price_drop = await service.notify(user_id, NotificationType.PRICE_DROP, {}, listing_id=listing_id)
+
+    assert new_match is not None
+    assert price_drop is not None

--- a/tests/unit/test_saved_search_endpoints.py
+++ b/tests/unit/test_saved_search_endpoints.py
@@ -1,0 +1,231 @@
+"""Endpoint-level tests for the saved-search API, following tests/unit/test_scrape_endpoints.py's
+pattern: real FastAPI app over ASGI, dependency overrides instead of a real Postgres/Redis/arq.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+import pytest_asyncio
+from fakeredis import FakeAsyncRedis
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.auth.email import get_email_sender
+from app.config import get_settings
+from app.db.base import Base
+from app.db.session import get_session
+from app.infrastructure.redis import get_redis
+from app.main import app
+from app.models.listing import Listing, ListingStatus
+from app.models.source import Source
+
+
+class RecordingEmailSender:
+    def __init__(self):
+        self.sent = []
+
+    async def send(self, to: str, subject: str, body: str) -> None:
+        self.sent.append({"to": to, "subject": subject, "body": body})
+
+    def last_token(self) -> str:
+        return self.sent[-1]["body"].rsplit("token=", 1)[-1]
+
+
+@pytest.fixture
+def email_sender():
+    return RecordingEmailSender()
+
+
+@pytest_asyncio.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:", poolclass=StaticPool, connect_args={"check_same_thread": False}
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    yield factory
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def client(session_factory, email_sender):
+    async def override_get_session():
+        async with session_factory() as session:
+            yield session
+
+    fake_redis = FakeAsyncRedis(decode_responses=True)
+
+    app.dependency_overrides[get_session] = override_get_session
+    app.dependency_overrides[get_redis] = lambda: fake_redis
+    app.dependency_overrides[get_email_sender] = lambda: email_sender
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as async_client:
+        yield async_client
+
+    app.dependency_overrides.clear()
+    await fake_redis.aclose()
+
+
+def _csrf_headers(client: AsyncClient) -> dict[str, str]:
+    settings = get_settings()
+    return {settings.csrf_header_name: client.cookies[settings.csrf_cookie_name]}
+
+
+async def _register_and_login(
+    client: AsyncClient, email_sender: RecordingEmailSender, email: str = "saver@example.com"
+) -> None:
+    await client.post("/api/v1/auth/register", json={"email": email, "password": "hunter2pass"})
+    token = email_sender.last_token()
+    await client.post("/api/v1/auth/verify-email", json={"token": token})
+    await client.post("/api/v1/auth/login", json={"email": email, "password": "hunter2pass"})
+
+
+async def test_create_saved_search(client, email_sender):
+    await _register_and_login(client, email_sender)
+
+    response = await client.post(
+        "/api/v1/saved-searches",
+        json={"name": "Skoda Octavia", "query": {"make": "Skoda"}},
+        headers=_csrf_headers(client),
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["name"] == "Skoda Octavia"
+    assert body["query"]["make"] == "Skoda"
+    assert body["enabled"] is True
+    assert body["last_run_at"] is None
+
+
+async def test_create_saved_search_requires_auth(client):
+    response = await client.post("/api/v1/saved-searches", json={"name": "x", "query": {}})
+    assert response.status_code == 401
+
+
+async def test_create_saved_search_enforces_free_plan_limit(client, email_sender):
+    await _register_and_login(client, email_sender)
+
+    for i in range(5):
+        response = await client.post(
+            "/api/v1/saved-searches",
+            json={"name": f"Search {i}", "query": {}},
+            headers=_csrf_headers(client),
+        )
+        assert response.status_code == 201
+
+    response = await client.post(
+        "/api/v1/saved-searches", json={"name": "One too many", "query": {}}, headers=_csrf_headers(client)
+    )
+    assert response.status_code == 402
+
+
+async def test_list_saved_searches_only_returns_own(client, email_sender):
+    await _register_and_login(client, email_sender, email="alice@example.com")
+    await client.post(
+        "/api/v1/saved-searches", json={"name": "Alice's search", "query": {}}, headers=_csrf_headers(client)
+    )
+    await client.post("/api/v1/auth/logout")
+
+    await _register_and_login(client, email_sender, email="bob@example.com")
+    await client.post(
+        "/api/v1/saved-searches", json={"name": "Bob's search", "query": {}}, headers=_csrf_headers(client)
+    )
+
+    response = await client.get("/api/v1/saved-searches")
+
+    assert response.status_code == 200
+    names = [s["name"] for s in response.json()]
+    assert names == ["Bob's search"]
+
+
+async def test_get_saved_search_404_for_other_users_search(client, email_sender):
+    await _register_and_login(client, email_sender, email="alice@example.com")
+    create_response = await client.post(
+        "/api/v1/saved-searches", json={"name": "Alice's search", "query": {}}, headers=_csrf_headers(client)
+    )
+    saved_search_id = create_response.json()["id"]
+    await client.post("/api/v1/auth/logout")
+
+    await _register_and_login(client, email_sender, email="bob@example.com")
+    response = await client.get(f"/api/v1/saved-searches/{saved_search_id}")
+
+    assert response.status_code == 404
+
+
+async def test_update_saved_search(client, email_sender):
+    await _register_and_login(client, email_sender)
+    create_response = await client.post(
+        "/api/v1/saved-searches", json={"name": "Skoda", "query": {"make": "Skoda"}}, headers=_csrf_headers(client)
+    )
+    saved_search_id = create_response.json()["id"]
+
+    response = await client.patch(
+        f"/api/v1/saved-searches/{saved_search_id}",
+        json={"enabled": False, "name": "Skoda (paused)"},
+        headers=_csrf_headers(client),
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["enabled"] is False
+    assert body["name"] == "Skoda (paused)"
+
+
+async def test_delete_saved_search(client, email_sender):
+    await _register_and_login(client, email_sender)
+    create_response = await client.post(
+        "/api/v1/saved-searches", json={"name": "Skoda", "query": {}}, headers=_csrf_headers(client)
+    )
+    saved_search_id = create_response.json()["id"]
+
+    response = await client.delete(f"/api/v1/saved-searches/{saved_search_id}", headers=_csrf_headers(client))
+    assert response.status_code == 204
+
+    list_response = await client.get("/api/v1/saved-searches")
+    assert list_response.json() == []
+
+
+async def test_run_saved_search_returns_matching_listings_and_sets_last_run_at(
+    client, email_sender, session_factory
+):
+    now = datetime.now(timezone.utc)
+    async with session_factory() as session:
+        source = Source(code="polovniautomobili", name="Polovni Automobili", domain="x.rs", country="RS")
+        session.add(source)
+        await session.flush()
+        session.add(
+            Listing(
+                source_id=source.id,
+                external_id="1",
+                canonical_url="https://x.rs/1",
+                title="Skoda Octavia",
+                make="Skoda",
+                model="Octavia",
+                production_year=2019,
+                mileage_km=100_000,
+                price=10_000,
+                currency="EUR",
+                status=ListingStatus.ACTIVE,
+                first_seen_at=now,
+                last_seen_at=now,
+                last_checked_at=now,
+            )
+        )
+        await session.commit()
+
+    await _register_and_login(client, email_sender)
+    create_response = await client.post(
+        "/api/v1/saved-searches", json={"name": "Skoda", "query": {"make": "Skoda"}}, headers=_csrf_headers(client)
+    )
+    saved_search_id = create_response.json()["id"]
+
+    response = await client.post(f"/api/v1/saved-searches/{saved_search_id}/run", headers=_csrf_headers(client))
+
+    assert response.status_code == 200
+    assert response.json()["total_listings"] == 1
+
+    get_response = await client.get(f"/api/v1/saved-searches/{saved_search_id}")
+    assert get_response.json()["last_run_at"] is not None

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -1,3 +1,4 @@
+import uuid
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -5,10 +6,11 @@ from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlalchemy.pool import StaticPool
 
 from app.db.base import Base
+from app.models.saved_search import SavedSearch
 from app.models.scheduled_scrape import ScheduledScrape
-from app.models.scrape_job import ScrapeJob, ScrapeJobStatus
+from app.models.scrape_job import ScrapeJob, ScrapeJobStatus, ScrapeJobType
 from app.models.source import Source
-from app.scraping.scheduler import run_due_scheduled_scrapes
+from app.scraping.scheduler import run_due_saved_search_scrapes, run_due_scheduled_scrapes
 
 
 @pytest.fixture
@@ -92,6 +94,80 @@ async def test_skips_schedule_not_yet_due(session_factory):
     async with session_factory() as session:
         jobs = (await session.execute(ScrapeJob.__table__.select())).fetchall()
         assert jobs == []
+
+
+async def _seed_saved_search(factory, user_id=None, last_run_at=None, enabled=True, query=None) -> uuid.UUID:
+    async with factory() as session:
+        saved_search = SavedSearch(
+            user_id=user_id or uuid.uuid4(),
+            name="Skoda search",
+            query=query or {"make": "Skoda"},
+            enabled=enabled,
+            last_run_at=last_run_at,
+        )
+        session.add(saved_search)
+        await session.commit()
+        return saved_search.id
+
+
+async def test_saved_search_scheduler_creates_job_for_never_run_search(session_factory):
+    source_id = await _seed_source(session_factory)
+    saved_search_id = await _seed_saved_search(session_factory, last_run_at=None)
+    redis = RecordingRedis()
+
+    await run_due_saved_search_scrapes({"session_factory": session_factory, "redis": redis})
+
+    async with session_factory() as session:
+        jobs = (await session.execute(ScrapeJob.__table__.select())).fetchall()
+        assert len(jobs) == 1
+        assert jobs[0].source_id == source_id
+        assert jobs[0].job_type == ScrapeJobType.SAVED_SEARCH_REFRESH
+        assert jobs[0].query["search_query"]["make"] == "Skoda"
+        assert jobs[0].query["max_pages"] == 5
+
+        saved_search = await session.get(SavedSearch, saved_search_id)
+        assert saved_search.last_run_at is not None
+
+    assert len(redis.enqueued) == 1
+    assert redis.enqueued[0][0] == "run_scrape_job"
+
+
+async def test_saved_search_scheduler_skips_recently_run_search(session_factory):
+    await _seed_source(session_factory)
+    recent = datetime.now(timezone.utc) - timedelta(minutes=5)
+    await _seed_saved_search(session_factory, last_run_at=recent)
+    redis = RecordingRedis()
+
+    await run_due_saved_search_scrapes({"session_factory": session_factory, "redis": redis})
+
+    assert redis.enqueued == []
+    async with session_factory() as session:
+        jobs = (await session.execute(ScrapeJob.__table__.select())).fetchall()
+        assert jobs == []
+
+
+async def test_saved_search_scheduler_skips_disabled_search(session_factory):
+    await _seed_source(session_factory)
+    stale = datetime.now(timezone.utc) - timedelta(hours=2)
+    await _seed_saved_search(session_factory, last_run_at=stale, enabled=False)
+    redis = RecordingRedis()
+
+    await run_due_saved_search_scrapes({"session_factory": session_factory, "redis": redis})
+
+    assert redis.enqueued == []
+
+
+async def test_saved_search_scheduler_creates_one_job_per_source(session_factory):
+    await _seed_source(session_factory)
+    async with session_factory() as session:
+        session.add(Source(code="mojauto", name="Moj Auto", domain="mojauto.rs", country="RS"))
+        await session.commit()
+    await _seed_saved_search(session_factory, last_run_at=None)
+    redis = RecordingRedis()
+
+    await run_due_saved_search_scrapes({"session_factory": session_factory, "redis": redis})
+
+    assert len(redis.enqueued) == 2
 
 
 async def test_skips_disabled_schedule(session_factory):

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -1,10 +1,15 @@
 import uuid
+from datetime import datetime, timezone
 
 import pytest
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlalchemy.pool import StaticPool
 
 from app.db.base import Base
+from app.models.follow import Follow
+from app.models.listing import Listing, ListingStatus
+from app.models.notification import Notification, NotificationType
 from app.models.scrape_job import ScrapeJob, ScrapeJobStatus, ScrapeJobType
 from app.models.source import Source
 from app.scraping import worker as worker_module
@@ -120,6 +125,62 @@ async def test_run_scrape_job_passes_stored_query_and_max_pages_to_run_scrape(wo
     assert received["source_code"] == "polovniautomobili"
     assert received["query"].make == "Audi"
     assert received["max_pages"] == 2
+
+
+class RecordingRedis:
+    def __init__(self):
+        self.enqueued: list[tuple[str, tuple]] = []
+
+    async def enqueue_job(self, function: str, *args) -> None:
+        self.enqueued.append((function, args))
+
+
+async def test_run_scrape_job_generates_and_enqueues_notification_for_price_drop(worker_session_factory, monkeypatch):
+    job_id = await _seed_job(worker_session_factory)
+    now = datetime.now(timezone.utc)
+
+    async with worker_session_factory() as session:
+        source = (await session.execute(Source.__table__.select())).first()
+        listing = Listing(
+            source_id=source.id,
+            external_id="1",
+            canonical_url="https://x.rs/1",
+            title="Skoda Octavia",
+            make="Skoda",
+            model="Octavia",
+            production_year=2019,
+            mileage_km=100_000,
+            price=10_000,
+            currency="EUR",
+            status=ListingStatus.ACTIVE,
+            first_seen_at=now,
+            last_seen_at=now,
+            last_checked_at=now,
+        )
+        session.add(listing)
+        await session.flush()
+        follower_id = uuid.uuid4()
+        session.add(Follow(user_id=follower_id, listing_id=listing.id))
+        await session.commit()
+        listing_id = listing.id
+
+    async def fake_run_scrape(session, source_code, query, max_pages=5, proxy_provider=None):
+        return ScrapeStats(listings_seen=1, listings_updated=1, price_drops=[(listing_id, 12_000, 10_000)])
+
+    monkeypatch.setattr(worker_module, "run_scrape", fake_run_scrape)
+
+    redis = RecordingRedis()
+    ctx = {"session_factory": worker_session_factory, "proxy_provider": NullProxyProvider(), "redis": redis}
+    await worker_module.run_scrape_job(ctx, str(job_id))
+
+    async with worker_session_factory() as session:
+        notifications = (await session.execute(select(Notification))).scalars().all()
+        assert len(notifications) == 1
+        assert notifications[0].user_id == follower_id
+        assert notifications[0].type == NotificationType.PRICE_DROP
+
+    assert len(redis.enqueued) == 1
+    assert redis.enqueued[0][0] == "send_notification_email"
 
 
 async def test_run_scrape_job_skips_already_cancelled_job(worker_session_factory, monkeypatch):


### PR DESCRIPTION
## Summary
- Saved searches: per-user CRUD + `/run` (`app/api/v1/saved_searches.py`), with a stub free-plan limit (5).
- Listing follows: `POST/DELETE /listings/{id}/follow`, `is_following` surfaced on both listing endpoints.
- In-app notifications: `GET /me/notifications`, `POST /me/notifications/{id}/read`.
- Email notifications: async via arq, isolated from the scrape job (an SMTP failure never fails the job), with a per-(user, type, listing) cooldown to avoid re-notifying on every refresh.
- Scheduler (#26): a cron job creates one `ScrapeJob(SAVED_SEARCH_REFRESH)` per due saved search × enabled source. Once a scrape completes, `app/notifications/matching.py` diffs its results (new listings / price drops, carried on `ScrapeStats`) against active saved searches and follows and generates the notifications — alerts fire strictly after fresh data lands, never off an independent poll.
- Frontend: "Мои поиски" (saved searches) page + save-current-filters button on search, Follow button on the listing page, a notifications page with an unread-count badge in the header.

Closes #20, #21, #22, #23, #26

## Test plan
- [x] `pytest tests/unit` — 162 passed
- [x] `ruff check` / `mypy` on all touched backend modules — clean
- [x] `tsc -b && vite build` — clean; `oxlint` — clean
- [x] Manually verified end-to-end against real Postgres/Redis/arq worker + Vite dev server: registered a user, saved a search, followed a listing, dropped its price, confirmed the worker matched it, created an in-app notification (visible with unread badge, mark-as-read works) and queued the email job (delivery attempt observed in worker logs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)