### PR TITLE
Add request pacing, direct-retry-before-proxy, and a modern UA pool

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -46,6 +46,17 @@ class Settings(BaseSettings):
     proxy_username: str | None = None
     proxy_password: str | None = None
 
+    # Scrape request pacing (docs/adr/05_ANTI_BOT_PROXY.md §8) — a courtesy to the source, not an
+    # anti-bot workaround. `ProxyHttpFetcher` spaces consecutive requests through one fetcher
+    # instance (i.e. within one scrape job) `scrape_request_delay_seconds` ± `_jitter_seconds`
+    # apart, and on a NETWORK_ERROR waits `scrape_network_error_retry_delay_seconds` to retry
+    # direct once (still no proxy) before falling back to the residential proxy — a connection
+    # reset right after a request that just worked is as likely a transient blip as an IP block,
+    # and the direct retry is free where a proxied one burns quota.
+    scrape_request_delay_seconds: float = 2.0
+    scrape_request_jitter_seconds: float = 1.0
+    scrape_network_error_retry_delay_seconds: float = 5.0
+
 
 @lru_cache
 def get_settings() -> Settings:

--- a/app/scraping/fetch_strategy.py
+++ b/app/scraping/fetch_strategy.py
@@ -6,6 +6,8 @@ directly. `HttpFetcher` and `ProxyHttpFetcher` share the same low-level request 
 """
 
 import asyncio
+import random
+import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Protocol
@@ -55,17 +57,47 @@ def _to_result(outcome: FetchOutcome, response: requests.Response | None, detail
     return FetchResult(outcome=outcome, text=response.text, status_code=response.status_code)
 
 
+class _RequestPacer:
+    """Sleeps so consecutive requests through one fetcher instance land `delay` ± `jitter` seconds
+    apart — a courtesy to the source (docs/adr/05_ANTI_BOT_PROXY.md §8), not an anti-bot
+    workaround. A fetcher is built fresh per scrape job (see app/scraping/pipeline.py), so the
+    first request of a job never waits; `delay=0` (the default) disables pacing entirely, which is
+    what every test gets unless it opts in.
+    """
+
+    def __init__(self, delay: float = 0.0, jitter: float = 0.0):
+        self.delay = delay
+        self.jitter = jitter
+        self._last_request_at: float | None = None
+
+    async def wait(self) -> None:
+        if self.delay > 0 and self._last_request_at is not None:
+            target = self.delay + random.uniform(-self.jitter, self.jitter)
+            remaining = target - (time.monotonic() - self._last_request_at)
+            if remaining > 0:
+                await asyncio.sleep(remaining)
+        self._last_request_at = time.monotonic()
+
+
 class HttpFetcher:
     """Direct HTTP fetch — no proxy, no block-like retry. `session` persists cookies across
     requests for whoever holds this fetcher.
     """
 
-    def __init__(self, timeout: int = 15, outcome_sink: Callable[[FetchOutcome], None] | None = None):
+    def __init__(
+        self,
+        timeout: int = 15,
+        outcome_sink: Callable[[FetchOutcome], None] | None = None,
+        delay: float = 0.0,
+        jitter: float = 0.0,
+    ):
         self.timeout = timeout
         self.session = requests.Session()
         self._outcome_sink = outcome_sink
+        self._pacer = _RequestPacer(delay, jitter)
 
     async def fetch(self, url: str) -> FetchResult:
+        await self._pacer.wait()
         outcome, response, detail = await asyncio.to_thread(_http_request, self.session, url, self.timeout, None)
         if self._outcome_sink is not None:
             self._outcome_sink(outcome)
@@ -73,13 +105,16 @@ class HttpFetcher:
 
 
 class ProxyHttpFetcher:
-    """Direct-first, proxy-fallback-only-when-worth-it (docs/adr/05_ANTI_BOT_PROXY.md §2-4). A
-    proxy attempt is made when the direct attempt looks block-like (403/429/challenge/captcha) or
-    came back as NETWORK_ERROR — a connection refused/reset instead of a proper 403 is itself a
-    plausible sign of an IP-level block, so it's worth the one retry. TIMEOUT and SERVER_ERROR are
-    NOT retried through the proxy: those point at the origin being slow/down, which a different
-    egress IP won't fix, and every proxied request burns the account's limited residential-proxy
-    quota.
+    """Direct-first, proxy-fallback-only-when-worth-it (docs/adr/05_ANTI_BOT_PROXY.md §2-4, §8).
+
+    On NETWORK_ERROR (connection refused/reset — no HTTP response at all), one direct retry is
+    made after `network_error_retry_delay` seconds, still with no proxy: a connection drop right
+    after a request that just worked is as plausibly a transient blip as an IP-level block, and
+    the direct retry is free where a proxied one burns the account's limited residential-proxy
+    quota. Only if that retry (or the very first attempt, for a block-like outcome) still looks
+    block-like or is another NETWORK_ERROR does a proxy attempt happen. TIMEOUT and SERVER_ERROR
+    are never retried through the proxy: those point at the origin being slow/down, which a
+    different egress IP won't fix.
 
     Ported out of what used to be `PolovniAutomobiliSource._fetch()` so any source adapter can
     reuse the same direct/proxy decision without reimplementing it.
@@ -93,20 +128,36 @@ class ProxyHttpFetcher:
         proxy_provider: ProxyProvider,
         timeout: int = 15,
         outcome_sink: Callable[[FetchOutcome], None] | None = None,
+        delay: float = 0.0,
+        jitter: float = 0.0,
+        network_error_retry_delay: float = 0.0,
     ):
         self.source = source
         self.proxy_provider = proxy_provider
         self.timeout = timeout
         self.session = requests.Session()
         self._outcome_sink = outcome_sink
+        self._pacer = _RequestPacer(delay, jitter)
+        self.network_error_retry_delay = network_error_retry_delay
+        self.jitter = jitter
 
     def _record(self, outcome: FetchOutcome) -> None:
         if self._outcome_sink is not None:
             self._outcome_sink(outcome)
 
+    async def _direct(self, url: str) -> tuple[FetchOutcome, requests.Response | None, str | None]:
+        return await asyncio.to_thread(_http_request, self.session, url, self.timeout, None)
+
     async def fetch(self, url: str) -> FetchResult:
-        outcome, response, detail = await asyncio.to_thread(_http_request, self.session, url, self.timeout, None)
+        await self._pacer.wait()
+        outcome, response, detail = await self._direct(url)
         self._record(outcome)
+
+        if outcome == FetchOutcome.NETWORK_ERROR and self.network_error_retry_delay > 0:
+            await asyncio.sleep(self.network_error_retry_delay + random.uniform(0, self.jitter))
+            outcome, response, detail = await self._direct(url)
+            self._record(outcome)
+
         if outcome not in self._PROXY_ELIGIBLE:
             return _to_result(outcome, response, detail)
 

--- a/app/sources/polovniautomobili/adapter.py
+++ b/app/sources/polovniautomobili/adapter.py
@@ -9,6 +9,7 @@ from collections.abc import AsyncIterator, Callable
 from typing import TypeVar
 from urllib.parse import urlencode
 
+from app.config import get_settings
 from app.scraping.fetch_outcome import FetchOutcome, ParserError
 from app.scraping.fetch_strategy import FetchStrategy, ProxyHttpFetcher, raise_for_blocked
 from app.scraping.proxy import ProxyProvider, get_proxy_provider
@@ -47,12 +48,19 @@ class PolovniAutomobiliSource:
         self.timeout = timeout
         self.max_pages = max_pages
         self._outcome_sink = outcome_sink
-        self.fetcher = fetcher if fetcher is not None else ProxyHttpFetcher(
-            source=self.source_code,
-            proxy_provider=proxy_provider if proxy_provider is not None else get_proxy_provider(),
-            timeout=timeout,
-            outcome_sink=outcome_sink,
-        )
+        if fetcher is not None:
+            self.fetcher = fetcher
+        else:
+            settings = get_settings()
+            self.fetcher = ProxyHttpFetcher(
+                source=self.source_code,
+                proxy_provider=proxy_provider if proxy_provider is not None else get_proxy_provider(),
+                timeout=timeout,
+                outcome_sink=outcome_sink,
+                delay=settings.scrape_request_delay_seconds,
+                jitter=settings.scrape_request_jitter_seconds,
+                network_error_retry_delay=settings.scrape_network_error_retry_delay_seconds,
+            )
 
     def build_search_url(self, query: SearchQuery, page: int = 1) -> str:
         params: list[tuple[str, str]] = [("page", str(page)), ("sort", "basic")]

--- a/scraping/utilities.py
+++ b/scraping/utilities.py
@@ -17,47 +17,152 @@ if not logger.hasHandlers():
     handler.setLevel(logging.INFO)
     logger.addHandler(handler)
 
-user_agent_list = [
-    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/93.0.4577.82 Safari/537.36',
-    'Mozilla/5.0 (iPhone; CPU iPhone OS 14_4_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.3 '
-    'Mobile/15E148 Safari/604.1',
-    'Mozilla/4.0 (compatible; MSIE 9.0; Windows NT 6.1)',
-    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.141 '
-    'Safari/537.36 Edg/87.0.664.75',
-    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.102 '
-    'Safari/537.36 Edge/18.18363',
+# Each profile is a complete, internally-consistent header set for one real browser/OS/device —
+# User-Agent, sec-ch-ua (Client Hints) and Accept all have to agree on the same browser and
+# version, or the mismatch itself becomes an anti-bot signal. default_request_headers() below
+# picks one whole profile at random; it never mixes fields from different profiles. A couple of
+# profiles use sr-RS Accept-Language since real visitors to a Serbian listings site plausibly do.
+_HEADER_PROFILES: list[dict[str, str]] = [
+    # Chrome / Windows
+    {
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) "
+                      "Chrome/131.0.0.0 Safari/537.36",
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
+        "Accept-Language": "en-US,en;q=0.9",
+        "Accept-Encoding": "gzip, deflate, br, zstd",
+        "Connection": "keep-alive",
+        "Upgrade-Insecure-Requests": "1",
+        "Sec-Fetch-Dest": "document",
+        "Sec-Fetch-Mode": "navigate",
+        "Sec-Fetch-Site": "none",
+        "Sec-Fetch-User": "?1",
+        "sec-ch-ua": '"Chromium";v="131", "Not_A Brand";v="24", "Google Chrome";v="131"',
+        "sec-ch-ua-mobile": "?0",
+        "sec-ch-ua-platform": '"Windows"',
+    },
+    # Chrome / macOS
+    {
+        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) "
+                      "Chrome/130.0.0.0 Safari/537.36",
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
+        "Accept-Language": "sr-RS,sr;q=0.9,en-US;q=0.8,en;q=0.7",
+        "Accept-Encoding": "gzip, deflate, br, zstd",
+        "Connection": "keep-alive",
+        "Upgrade-Insecure-Requests": "1",
+        "Sec-Fetch-Dest": "document",
+        "Sec-Fetch-Mode": "navigate",
+        "Sec-Fetch-Site": "none",
+        "Sec-Fetch-User": "?1",
+        "sec-ch-ua": '"Chromium";v="130", "Not_A Brand";v="24", "Google Chrome";v="130"',
+        "sec-ch-ua-mobile": "?0",
+        "sec-ch-ua-platform": '"macOS"',
+    },
+    # Chrome / Linux
+    {
+        "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) "
+                      "Chrome/129.0.0.0 Safari/537.36",
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
+        "Accept-Language": "en-US,en;q=0.9",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Connection": "keep-alive",
+        "Upgrade-Insecure-Requests": "1",
+        "Sec-Fetch-Dest": "document",
+        "Sec-Fetch-Mode": "navigate",
+        "Sec-Fetch-Site": "none",
+        "Sec-Fetch-User": "?1",
+        "sec-ch-ua": '"Chromium";v="129", "Not_A Brand";v="24", "Google Chrome";v="129"',
+        "sec-ch-ua-mobile": "?0",
+        "sec-ch-ua-platform": '"Linux"',
+    },
+    # Edge / Windows
+    {
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) "
+                      "Chrome/131.0.0.0 Safari/537.36 Edg/131.0.0.0",
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
+        "Accept-Language": "en-US,en;q=0.9",
+        "Accept-Encoding": "gzip, deflate, br, zstd",
+        "Connection": "keep-alive",
+        "Upgrade-Insecure-Requests": "1",
+        "Sec-Fetch-Dest": "document",
+        "Sec-Fetch-Mode": "navigate",
+        "Sec-Fetch-Site": "none",
+        "Sec-Fetch-User": "?1",
+        "sec-ch-ua": '"Chromium";v="131", "Not_A Brand";v="24", "Microsoft Edge";v="131"',
+        "sec-ch-ua-mobile": "?0",
+        "sec-ch-ua-platform": '"Windows"',
+    },
+    # Firefox / Windows — Firefox never sends Client Hints (no sec-ch-ua*)
+    {
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:133.0) Gecko/20100101 Firefox/133.0",
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+        "Accept-Language": "en-US,en;q=0.5",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Connection": "keep-alive",
+        "Upgrade-Insecure-Requests": "1",
+        "Sec-Fetch-Dest": "document",
+        "Sec-Fetch-Mode": "navigate",
+        "Sec-Fetch-Site": "none",
+        "Sec-Fetch-User": "?1",
+    },
+    # Firefox / macOS
+    {
+        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:133.0) Gecko/20100101 Firefox/133.0",
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+        "Accept-Language": "sr-RS,sr;q=0.8,en-US;q=0.5,en;q=0.3",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Connection": "keep-alive",
+        "Upgrade-Insecure-Requests": "1",
+        "Sec-Fetch-Dest": "document",
+        "Sec-Fetch-Mode": "navigate",
+        "Sec-Fetch-Site": "none",
+        "Sec-Fetch-User": "?1",
+    },
+    # Safari / macOS — Safari never sends Client Hints either
+    {
+        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) "
+                      "Version/18.1 Safari/605.1.15",
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+        "Accept-Language": "en-US,en;q=0.9",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Connection": "keep-alive",
+        "Upgrade-Insecure-Requests": "1",
+    },
+    # Chrome / Android — mobile
+    {
+        "User-Agent": "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) "
+                      "Chrome/131.0.0.0 Mobile Safari/537.36",
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
+        "Accept-Language": "sr-RS,sr;q=0.9,en-US;q=0.8,en;q=0.7",
+        "Accept-Encoding": "gzip, deflate, br, zstd",
+        "Connection": "keep-alive",
+        "Upgrade-Insecure-Requests": "1",
+        "Sec-Fetch-Dest": "document",
+        "Sec-Fetch-Mode": "navigate",
+        "Sec-Fetch-Site": "none",
+        "Sec-Fetch-User": "?1",
+        "sec-ch-ua": '"Chromium";v="131", "Not_A Brand";v="24", "Google Chrome";v="131"',
+        "sec-ch-ua-mobile": "?1",
+        "sec-ch-ua-platform": '"Android"',
+    },
+    # Safari / iOS — mobile
+    {
+        "User-Agent": "Mozilla/5.0 (iPhone; CPU iPhone OS 18_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like "
+                      "Gecko) Version/18.1 Mobile/15E148 Safari/604.1",
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+        "Accept-Language": "en-US,en;q=0.9",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Connection": "keep-alive",
+        "Upgrade-Insecure-Requests": "1",
+    },
 ]
 
 
-def default_request_headers():
-    return random.choice([
-        {
-            'User-Agent': user_agent_list[random.randint(0, len(user_agent_list) - 1)],
-            'Accept-Language': 'en-US,en;q=0.9',
-            'Accept-Encoding': 'gzip, deflate, br',
-            'Connection': 'keep-alive',
-            'Upgrade-Insecure-Requests': '1',
-            'Sec-Fetch-Dest': 'document',
-            'Sec-Fetch-Mode': 'navigate',
-            'Sec-Fetch-Site': 'same-origin',
-            'Sec-Fetch-User': '?1'
-        },
-        {
-            "upgrade-insecure-requests": "1",
-            "user-agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.5060.53 "
-                          "Safari/537.36",
-            "accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,"
-                      "application/signed-exchange;v=b3;q=0.9",
-            "sec-ch-ua": "\".Not/A)Brand\";v=\"99\", \"Google Chrome\";v=\"103\", \"Chromium\";v=\"103\"",
-            "sec-ch-ua-mobile": "?0",
-            "sec-ch-ua-platform": "\"Linux\"",
-            "sec-fetch-site": "none",
-            "sec-fetch-mod": "",
-            "sec-fetch-user": "?1",
-            "accept-encoding": "gzip, deflate, br",
-            "accept-language": "fr-CH,fr;q=0.9,en-US;q=0.8,en;q=0.7"
-        }
-    ])
+def default_request_headers() -> dict[str, str]:
+    """Picks one whole header profile at random — see _HEADER_PROFILES for why fields are never
+    mixed across profiles. Returns a copy so a caller mutating the result can't corrupt the shared
+    profile for the next pick.
+    """
+    return dict(random.choice(_HEADER_PROFILES))
 
 
 def get_soup_from_response(response):

--- a/tests/unit/test_fetch_strategy.py
+++ b/tests/unit/test_fetch_strategy.py
@@ -1,3 +1,5 @@
+import time
+
 import pytest
 import requests
 
@@ -126,6 +128,93 @@ async def test_proxy_http_fetcher_retries_via_proxy_on_network_error(monkeypatch
     assert result.text == "via proxy"
     assert len(proxy_provider.successes) == 1
     assert proxy_provider.failures == []
+
+
+async def test_proxy_http_fetcher_retries_direct_once_before_touching_proxy(monkeypatch):
+    proxy_provider = FakeProxyProvider()
+    fetcher = ProxyHttpFetcher(
+        source="polovniautomobili", proxy_provider=proxy_provider, network_error_retry_delay=0.01
+    )
+    calls = {"direct": 0}
+
+    def fake_get(url, timeout, headers, proxies=None):
+        if proxies is None:
+            calls["direct"] += 1
+            if calls["direct"] == 1:
+                raise requests.ConnectionError("Connection reset by peer")
+            return _response(200, "direct retry ok")
+        raise AssertionError("proxy should not be touched — the direct retry succeeded")
+
+    monkeypatch.setattr(fetcher.session, "get", fake_get)
+
+    result = await fetcher.fetch("https://example.com")
+
+    assert result.outcome == FetchOutcome.SUCCESS
+    assert result.text == "direct retry ok"
+    assert calls["direct"] == 2
+    assert proxy_provider.successes == []
+    assert proxy_provider.failures == []
+
+
+async def test_proxy_http_fetcher_falls_back_to_proxy_when_direct_retry_also_fails(monkeypatch):
+    proxy_provider = FakeProxyProvider()
+    fetcher = ProxyHttpFetcher(
+        source="polovniautomobili", proxy_provider=proxy_provider, network_error_retry_delay=0.01
+    )
+    calls = {"direct": 0}
+
+    def fake_get(url, timeout, headers, proxies=None):
+        if proxies is None:
+            calls["direct"] += 1
+            raise requests.ConnectionError("still down")
+        return _response(200, "via proxy")
+
+    monkeypatch.setattr(fetcher.session, "get", fake_get)
+
+    result = await fetcher.fetch("https://example.com")
+
+    assert result.outcome == FetchOutcome.SUCCESS
+    assert result.text == "via proxy"
+    assert calls["direct"] == 2
+    assert len(proxy_provider.successes) == 1
+
+
+async def test_proxy_http_fetcher_skips_direct_retry_when_no_retry_delay_configured(monkeypatch):
+    """network_error_retry_delay=0 (the default) disables the direct retry — network_error goes
+    straight to the proxy, same as before this behavior existed.
+    """
+    proxy_provider = FakeProxyProvider()
+    fetcher = ProxyHttpFetcher(source="polovniautomobili", proxy_provider=proxy_provider)
+    calls = {"direct": 0}
+
+    def fake_get(url, timeout, headers, proxies=None):
+        if proxies is None:
+            calls["direct"] += 1
+            raise requests.ConnectionError("Connection reset by peer")
+        return _response(200, "via proxy")
+
+    monkeypatch.setattr(fetcher.session, "get", fake_get)
+
+    result = await fetcher.fetch("https://example.com")
+
+    assert result.outcome == FetchOutcome.SUCCESS
+    assert calls["direct"] == 1
+    assert len(proxy_provider.successes) == 1
+
+
+async def test_proxy_http_fetcher_paces_consecutive_requests_but_not_the_first(monkeypatch):
+    proxy_provider = FakeProxyProvider()
+    fetcher = ProxyHttpFetcher(source="polovniautomobili", proxy_provider=proxy_provider, delay=0.05, jitter=0.0)
+    monkeypatch.setattr(fetcher.session, "get", lambda *a, **kw: _response(200, "ok"))
+
+    start = time.monotonic()
+    await fetcher.fetch("https://example.com/page1")
+    first_elapsed = time.monotonic() - start
+    await fetcher.fetch("https://example.com/page2")
+    total_elapsed = time.monotonic() - start
+
+    assert first_elapsed < 0.05
+    assert total_elapsed >= 0.05
 
 
 async def test_proxy_http_fetcher_reports_failure_when_network_error_persists_through_proxy(monkeypatch):

--- a/tests/unit/test_polovni_adapter.py
+++ b/tests/unit/test_polovni_adapter.py
@@ -77,6 +77,17 @@ def test_parse_listing_extracts_full_detail():
     assert listing.image_url == "https://cdn.polovniautomobili.com/user-images/thumbs/3013/30136732/0d3bcb74b14a.jpg"
 
 
+def test_fetcher_is_configured_from_settings():
+    from app.config import get_settings
+
+    adapter = PolovniAutomobiliSource()
+    settings = get_settings()
+
+    assert adapter.fetcher._pacer.delay == settings.scrape_request_delay_seconds
+    assert adapter.fetcher._pacer.jitter == settings.scrape_request_jitter_seconds
+    assert adapter.fetcher.network_error_retry_delay == settings.scrape_network_error_retry_delay_seconds
+
+
 def test_build_search_url_includes_filters():
     from app.search.query import SearchQuery
 


### PR DESCRIPTION
## Summary
- **Request pacing**: `ProxyHttpFetcher` now spaces consecutive requests through one fetcher instance (i.e. within one scrape job) `scrape_request_delay_seconds` ± `scrape_request_jitter_seconds` apart (defaults 2s ± 1s, configurable via `Settings`). Disabled by default (`delay=0`) for anyone constructing a fetcher directly — only the polovni adapter opts in, reading from `Settings` — so no existing test got slower.
- **Direct-retry-before-proxy on network_error**: on `NETWORK_ERROR` (connection refused/reset), one retry is made directly — still no proxy — after `scrape_network_error_retry_delay_seconds` (default 5s). Only if that retry (or the original attempt, for a block-like outcome) still looks bad does a proxy attempt happen. A connection drop right after a request that just worked is as plausibly a transient blip as an IP-level block, and the direct retry is free where a proxied one burns IPRoyal quota.
- **Modernized UA pool**: replaced the stale/small pool in `scraping/utilities.py` (Chrome 70/87/93/103, IE9(!), a 2021 iOS build) with 9 internally-consistent header profiles spanning modern Chrome/Firefox/Safari/Edge on desktop plus Android/iOS mobile. Each profile's User-Agent, `sec-ch-ua` and `Accept` now agree on the same browser/version — the old code randomized UA and the rest of the header set independently, so a request could carry e.g. a Chrome 93 UA next to `sec-ch-ua: "Google Chrome";v="103"`, which is itself a fingerprinting mismatch.

Context: scaling the polovniautomobili crawl target from a handful of test brands to ~15-25k listings (most popular makes) out of the site's ~80k total, so pacing/UA hygiene now actually matters at that volume.

## Test plan
- [x] `tests/unit/test_fetch_strategy.py` — new: direct-retry-then-success skips the proxy entirely, direct-retry-then-still-failing falls back to proxy, retry-delay=0 keeps the old immediate-proxy behavior, pacing waits between two fetches but not before the first
- [x] `tests/unit/test_polovni_adapter.py` — new: adapter's fetcher picks up delay/jitter/retry values from `Settings`
- [x] `.venv/bin/python -m pytest tests/unit -q` — 149 passed
- [x] `ruff check` / `mypy` on changed files — clean