### PR TITLE
Show job stats/params and add date filter to admin scrape jobs page

### DIFF
--- a/app/api/v1/scrape.py
+++ b/app/api/v1/scrape.py
@@ -43,6 +43,8 @@ async def list_scrape_jobs(
     _current_user: User = Depends(require_admin),
     status: ScrapeJobStatus | None = None,
     source_id: uuid.UUID | None = None,
+    date_from: datetime | None = None,
+    date_to: datetime | None = None,
     limit: int = Query(default=50, ge=1, le=200),
     offset: int = Query(default=0, ge=0),
 ) -> list[ScrapeJobOut]:
@@ -51,6 +53,10 @@ async def list_scrape_jobs(
         stmt = stmt.where(ScrapeJob.status == status)
     if source_id is not None:
         stmt = stmt.where(ScrapeJob.source_id == source_id)
+    if date_from is not None:
+        stmt = stmt.where(ScrapeJob.created_at >= date_from)
+    if date_to is not None:
+        stmt = stmt.where(ScrapeJob.created_at <= date_to)
     jobs = (await session.execute(stmt)).scalars().all()
     return [ScrapeJobOut.model_validate(job) for job in jobs]
 

--- a/app/scraping/schemas.py
+++ b/app/scraping/schemas.py
@@ -38,6 +38,7 @@ class ScrapeJobOut(BaseModel):
     job_type: ScrapeJobType
     status: ScrapeJobStatus
     query: dict | None
+    created_at: datetime
     started_at: datetime | None
     finished_at: datetime | None
     stats: dict | None

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -55,15 +55,36 @@ export interface ScrapeJobOut {
   job_type: ScrapeJobType
   status: ScrapeJobStatus
   query: Record<string, unknown> | null
+  created_at: string
   started_at: string | null
   finished_at: string | null
   stats: Record<string, unknown> | null
   error: Record<string, unknown> | null
 }
 
+export interface ScrapeJobStats {
+  listings_seen?: number
+  listings_created?: number
+  listings_updated?: number
+  listings_removed?: number
+  outcome_counts?: Record<string, number>
+}
+
+export interface ListJobsFilters {
+  status?: ScrapeJobStatus
+  dateFrom?: string
+  dateTo?: string
+}
+
 export const scrapeApi = {
-  listJobs: (status?: ScrapeJobStatus) =>
-    apiFetch<ScrapeJobOut[]>(`/api/v1/scrape/jobs${status ? `?status=${status}` : ''}`),
+  listJobs: (filters: ListJobsFilters = {}) => {
+    const params = new URLSearchParams()
+    if (filters.status) params.set('status', filters.status)
+    if (filters.dateFrom) params.set('date_from', filters.dateFrom)
+    if (filters.dateTo) params.set('date_to', filters.dateTo)
+    const qs = params.toString()
+    return apiFetch<ScrapeJobOut[]>(`/api/v1/scrape/jobs${qs ? `?${qs}` : ''}`)
+  },
 
   createJob: (sourceCode: string, make?: string, maxPages = 5) =>
     apiFetch<ScrapeJobOut>('/api/v1/scrape/jobs', {

--- a/frontend/src/lib/search.ts
+++ b/frontend/src/lib/search.ts
@@ -20,6 +20,16 @@ export interface SearchQuery {
   location?: string
 }
 
+// Mirrors SearchQuery.describe() in app/search/query.py.
+export function describeQuery(query: SearchQuery): string {
+  const parts: string[] = []
+  if (query.make) parts.push(String(query.make))
+  if (Array.isArray(query.models) && query.models.length) parts.push((query.models as string[]).join('/'))
+  if (query.year_min || query.year_max) parts.push(`${query.year_min ?? '…'}–${query.year_max ?? '…'}`)
+  if (query.price_min || query.price_max) parts.push(`€${query.price_min ?? '…'}–${query.price_max ?? '…'}`)
+  return parts.length ? parts.join(', ') : 'Все объявления'
+}
+
 // Mirrors ALLOWED_GROUP_FIELDS in app/search/service.py.
 export type GroupField = 'make' | 'model' | 'production_year' | 'fuel_type' | 'transmission' | 'engine_volume_cc' | 'body_type'
 

--- a/frontend/src/pages/AdminJobsPage.tsx
+++ b/frontend/src/pages/AdminJobsPage.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { EmptyState, ErrorState, LoadingState } from '../components/StateMessage'
-import { ApiError, type ScrapeJobStatus, type ScrapeJobType, scrapeApi } from '../lib/api'
+import { ApiError, type ScrapeJobStats, type ScrapeJobStatus, type ScrapeJobType, scrapeApi } from '../lib/api'
+import { describeQuery, type SearchQuery } from '../lib/search'
 
 const STATUS_OPTIONS: { value: ScrapeJobStatus | ''; label: string }[] = [
   { value: '', label: 'Все статусы' },
@@ -42,8 +43,31 @@ function formatTimestamp(iso: string | null): string {
   return new Date(iso).toLocaleString('ru-RU')
 }
 
+// job.query is {"search_query": SearchQuery, "max_pages": number} — see encode_job_query in
+// app/scraping/schemas.py.
+function describeJobQuery(query: Record<string, unknown> | null): string {
+  if (!query) return 'Все объявления'
+  const searchQuery = (query.search_query as SearchQuery | undefined) ?? {}
+  const maxPages = typeof query.max_pages === 'number' ? query.max_pages : undefined
+  const filters = describeQuery(searchQuery)
+  return maxPages ? `${filters} (до ${maxPages} стр.)` : filters
+}
+
+function describeJobStats(stats: Record<string, unknown> | null): string {
+  if (!stats) return '—'
+  const s = stats as ScrapeJobStats
+  const seen = s.listings_seen ?? 0
+  const created = s.listings_created ?? 0
+  const updated = s.listings_updated ?? 0
+  const removed = s.listings_removed ?? 0
+  return `всего ${seen}, новых ${created}, обновлено ${updated}, удалено ${removed}`
+}
+
 export function AdminJobsPage() {
   const [statusFilter, setStatusFilter] = useState<ScrapeJobStatus | ''>('')
+  const [dateFrom, setDateFrom] = useState('')
+  const [dateTo, setDateTo] = useState('')
+  const [jobsCollapsed, setJobsCollapsed] = useState(false)
   const [make, setMake] = useState('')
   const [maxPages, setMaxPages] = useState(5)
   const [formError, setFormError] = useState<string | null>(null)
@@ -59,8 +83,13 @@ export function AdminJobsPage() {
   const [pendingScheduleId, setPendingScheduleId] = useState<string | null>(null)
 
   const jobsQuery = useQuery({
-    queryKey: ['admin', 'scrape-jobs', statusFilter],
-    queryFn: () => scrapeApi.listJobs(statusFilter || undefined),
+    queryKey: ['admin', 'scrape-jobs', statusFilter, dateFrom, dateTo],
+    queryFn: () =>
+      scrapeApi.listJobs({
+        status: statusFilter || undefined,
+        dateFrom: dateFrom ? `${dateFrom}T00:00:00` : undefined,
+        dateTo: dateTo ? `${dateTo}T23:59:59` : undefined,
+      }),
   })
 
   const schedulesQuery = useQuery({
@@ -205,79 +234,127 @@ export function AdminJobsPage() {
       </form>
 
       <div>
-        <div className="mb-3 flex items-center justify-between">
-          <h2 className="text-sm font-medium text-slate-900">Все задачи</h2>
-          <select
-            value={statusFilter}
-            onChange={(e) => setStatusFilter(e.target.value as ScrapeJobStatus | '')}
-            className="rounded-md border border-slate-300 px-3 py-1.5 text-sm"
-          >
-            {STATUS_OPTIONS.map((opt) => (
-              <option key={opt.value} value={opt.value}>
-                {opt.label}
-              </option>
-            ))}
-          </select>
+        <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+          <div className="flex items-center gap-2">
+            <h2 className="text-sm font-medium text-slate-900">Все задачи</h2>
+            <button
+              type="button"
+              onClick={() => setJobsCollapsed((prev) => !prev)}
+              className="rounded-md border border-slate-300 px-2 py-1 text-xs font-medium text-slate-600 hover:bg-slate-100"
+            >
+              {jobsCollapsed ? 'Развернуть' : 'Свернуть'}
+            </button>
+            <a href="#schedules" className="text-xs font-medium text-slate-500 underline hover:text-slate-700">
+              К расписаниям ↓
+            </a>
+          </div>
+          <div className="flex flex-wrap items-end gap-3">
+            <div>
+              <label className="mb-1 block text-xs font-medium text-slate-600" htmlFor="job-date-from">
+                С даты
+              </label>
+              <input
+                id="job-date-from"
+                type="date"
+                value={dateFrom}
+                onChange={(e) => setDateFrom(e.target.value)}
+                className="rounded-md border border-slate-300 px-3 py-1.5 text-sm"
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-xs font-medium text-slate-600" htmlFor="job-date-to">
+                По дату
+              </label>
+              <input
+                id="job-date-to"
+                type="date"
+                value={dateTo}
+                onChange={(e) => setDateTo(e.target.value)}
+                className="rounded-md border border-slate-300 px-3 py-1.5 text-sm"
+              />
+            </div>
+            <select
+              value={statusFilter}
+              onChange={(e) => setStatusFilter(e.target.value as ScrapeJobStatus | '')}
+              className="rounded-md border border-slate-300 px-3 py-1.5 text-sm"
+            >
+              {STATUS_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </div>
         </div>
 
-        {jobsQuery.isLoading && <LoadingState />}
-        {jobsQuery.isError && <ErrorState message="Не удалось загрузить задачи" onRetry={() => jobsQuery.refetch()} />}
-        {jobsQuery.isSuccess && jobsQuery.data.length === 0 && <EmptyState message="Задач пока нет" />}
+        {!jobsCollapsed && (
+          <>
+            {jobsQuery.isLoading && <LoadingState />}
+            {jobsQuery.isError && (
+              <ErrorState message="Не удалось загрузить задачи" onRetry={() => jobsQuery.refetch()} />
+            )}
+            {jobsQuery.isSuccess && jobsQuery.data.length === 0 && <EmptyState message="Задач пока нет" />}
 
-        {jobsQuery.isSuccess && jobsQuery.data.length > 0 && (
-          <div className="overflow-x-auto rounded-lg border border-slate-200 bg-white">
-            <table className="w-full text-left text-sm">
-              <thead className="border-b border-slate-200 bg-slate-50 text-xs uppercase text-slate-500">
-                <tr>
-                  <th className="px-4 py-2">Тип</th>
-                  <th className="px-4 py-2">Статус</th>
-                  <th className="px-4 py-2">Начало</th>
-                  <th className="px-4 py-2">Конец</th>
-                  <th className="px-4 py-2">Ошибка</th>
-                  <th className="px-4 py-2" />
-                </tr>
-              </thead>
-              <tbody>
-                {jobsQuery.data.map((job) => (
-                  <tr key={job.id} className="border-b border-slate-100 last:border-0">
-                    <td className="px-4 py-2 text-slate-700">{JOB_TYPE_LABELS[job.job_type]}</td>
-                    <td className="px-4 py-2 text-slate-700">{job.status}</td>
-                    <td className="px-4 py-2 text-slate-500">{formatTimestamp(job.started_at)}</td>
-                    <td className="px-4 py-2 text-slate-500">{formatTimestamp(job.finished_at)}</td>
-                    <td className="px-4 py-2 max-w-xs truncate text-slate-500">
-                      {job.error ? JSON.stringify(job.error) : '—'}
-                    </td>
-                    <td className="px-4 py-2 text-right">
-                      {CANCELLABLE.has(job.status) && (
-                        <button
-                          type="button"
-                          disabled={pendingActionId === job.id}
-                          onClick={() => handleCancel(job.id)}
-                          className="rounded-md border border-slate-300 px-2 py-1 text-xs font-medium text-slate-700 hover:bg-slate-100 disabled:opacity-50"
-                        >
-                          Отменить
-                        </button>
-                      )}
-                      {RETRYABLE.has(job.status) && (
-                        <button
-                          type="button"
-                          disabled={pendingActionId === job.id}
-                          onClick={() => handleRetry(job.id)}
-                          className="ml-2 rounded-md border border-slate-300 px-2 py-1 text-xs font-medium text-slate-700 hover:bg-slate-100 disabled:opacity-50"
-                        >
-                          Повторить
-                        </button>
-                      )}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
+            {jobsQuery.isSuccess && jobsQuery.data.length > 0 && (
+              <div className="overflow-x-auto rounded-lg border border-slate-200 bg-white">
+                <table className="w-full text-left text-sm">
+                  <thead className="border-b border-slate-200 bg-slate-50 text-xs uppercase text-slate-500">
+                    <tr>
+                      <th className="px-4 py-2">Тип</th>
+                      <th className="px-4 py-2">Параметры</th>
+                      <th className="px-4 py-2">Статус</th>
+                      <th className="px-4 py-2">Начало</th>
+                      <th className="px-4 py-2">Конец</th>
+                      <th className="px-4 py-2">Результат</th>
+                      <th className="px-4 py-2">Ошибка</th>
+                      <th className="px-4 py-2" />
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {jobsQuery.data.map((job) => (
+                      <tr key={job.id} className="border-b border-slate-100 last:border-0">
+                        <td className="px-4 py-2 text-slate-700">{JOB_TYPE_LABELS[job.job_type]}</td>
+                        <td className="px-4 py-2 max-w-xs text-slate-500">{describeJobQuery(job.query)}</td>
+                        <td className="px-4 py-2 text-slate-700">{job.status}</td>
+                        <td className="px-4 py-2 text-slate-500">{formatTimestamp(job.started_at)}</td>
+                        <td className="px-4 py-2 text-slate-500">{formatTimestamp(job.finished_at)}</td>
+                        <td className="px-4 py-2 text-slate-500">{describeJobStats(job.stats)}</td>
+                        <td className="px-4 py-2 max-w-xs truncate text-slate-500">
+                          {job.error ? JSON.stringify(job.error) : '—'}
+                        </td>
+                        <td className="px-4 py-2 text-right">
+                          {CANCELLABLE.has(job.status) && (
+                            <button
+                              type="button"
+                              disabled={pendingActionId === job.id}
+                              onClick={() => handleCancel(job.id)}
+                              className="rounded-md border border-slate-300 px-2 py-1 text-xs font-medium text-slate-700 hover:bg-slate-100 disabled:opacity-50"
+                            >
+                              Отменить
+                            </button>
+                          )}
+                          {RETRYABLE.has(job.status) && (
+                            <button
+                              type="button"
+                              disabled={pendingActionId === job.id}
+                              onClick={() => handleRetry(job.id)}
+                              className="ml-2 rounded-md border border-slate-300 px-2 py-1 text-xs font-medium text-slate-700 hover:bg-slate-100 disabled:opacity-50"
+                            >
+                              Повторить
+                            </button>
+                          )}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </>
         )}
       </div>
 
-      <div>
+      <div id="schedules" className="scroll-mt-4">
         <h2 className="mb-1 text-sm font-medium text-slate-900">Расписания</h2>
         <p className="mb-3 text-sm text-slate-600">
           Регулярный запуск задачи с заданным интервалом — держит данные актуальными без ручных запусков.

--- a/frontend/src/pages/SavedSearchesPage.tsx
+++ b/frontend/src/pages/SavedSearchesPage.tsx
@@ -3,18 +3,9 @@ import { useState } from 'react'
 import { Link } from 'react-router-dom'
 import { ApiError } from '../lib/client'
 import { formatDate } from '../lib/format'
-import type { SearchQuery } from '../lib/search'
+import { describeQuery } from '../lib/search'
 import { savedSearchesApi } from '../lib/savedSearches'
 import { EmptyState, ErrorState, LoadingState } from '../components/StateMessage'
-
-function describeQuery(query: SearchQuery): string {
-  const parts: string[] = []
-  if (query.make) parts.push(String(query.make))
-  if (Array.isArray(query.models) && query.models.length) parts.push((query.models as string[]).join('/'))
-  if (query.year_min || query.year_max) parts.push(`${query.year_min ?? '…'}–${query.year_max ?? '…'}`)
-  if (query.price_min || query.price_max) parts.push(`€${query.price_min ?? '…'}–${query.price_max ?? '…'}`)
-  return parts.length ? parts.join(', ') : 'Все объявления'
-}
 
 export function SavedSearchesPage() {
   const [pendingId, setPendingId] = useState<string | null>(null)

--- a/tests/unit/test_scrape_endpoints.py
+++ b/tests/unit/test_scrape_endpoints.py
@@ -2,6 +2,8 @@
 pattern: real FastAPI app over ASGI, dependency overrides instead of a real Postgres/Redis/arq.
 """
 
+from datetime import datetime, timedelta
+
 import pytest
 import pytest_asyncio
 from fakeredis import FakeAsyncRedis
@@ -238,6 +240,30 @@ async def test_list_scrape_jobs_filters_by_status(client, email_sender, session_
     assert response.status_code == 200
     body = response.json()
     assert [job["id"] for job in body] == [job_id]
+
+
+async def test_list_scrape_jobs_filters_by_date_range(client, email_sender, session_factory):
+    await _register_login_and_promote(client, email_sender, session_factory)
+    create_response = await client.post(
+        "/api/v1/scrape/jobs", json={"source_code": "polovniautomobili"}, headers=_csrf_headers(client)
+    )
+    job_id = create_response.json()["id"]
+    created_at = datetime.fromisoformat(create_response.json()["created_at"])
+
+    future_from = (created_at + timedelta(days=1)).isoformat()
+    response = await client.get("/api/v1/scrape/jobs", params={"date_from": future_from})
+    assert response.status_code == 200
+    assert response.json() == []
+
+    past_from = (created_at - timedelta(days=1)).isoformat()
+    response = await client.get("/api/v1/scrape/jobs", params={"date_from": past_from})
+    assert response.status_code == 200
+    assert [job["id"] for job in response.json()] == [job_id]
+
+    past_to = (created_at - timedelta(days=1)).isoformat()
+    response = await client.get("/api/v1/scrape/jobs", params={"date_to": past_to})
+    assert response.status_code == 200
+    assert response.json() == []
 
 
 async def test_list_scrape_jobs_requires_admin(client, email_sender):


### PR DESCRIPTION
## Summary
- Add a "Параметры" column to the admin jobs table decoding `job.query` (search filters + max pages) — reuses a new shared `describeQuery` helper (also now used by `SavedSearchesPage`).
- Add a "Результат" column decoding `job.stats` (listings seen/created/updated/removed).
- Add a date-range filter (`С даты` / `По дату`) for the jobs list, backed by new `date_from`/`date_to` query params on `GET /api/v1/scrape/jobs`, filtering on `created_at`. `ScrapeJobOut` now also exposes `created_at`.
- Add a collapse toggle for the jobs table and a "К расписаниям ↓" jump link to the schedules block.

## Test plan
- [x] `pytest tests/unit/test_scrape_endpoints.py` — 21 passed (added a new test for the date filter)
- [x] `npx tsc --noEmit` — clean
- [x] Manually verified in-browser against a local API + seeded jobs: params/result columns render, date filter narrows/empties the list correctly, collapse toggle and jump link work

🤖 Generated with [Claude Code](https://claude.com/claude-code)