### PR TITLE
Fix concurrent scrape jobs crashing on duplicate listing inserts

### DIFF
--- a/app/listings/repository.py
+++ b/app/listings/repository.py
@@ -3,6 +3,7 @@ import uuid
 from datetime import datetime, timezone
 
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.follow import Follow
@@ -49,6 +50,11 @@ class ListingRepository:
         Snapshot only if price/mileage/title actually changed. Returns (listing, is_new,
         previous_price) — previous_price is the price before this update, only set when the price
         actually changed (used by app/notifications/matching.py to detect drops for #21/#26).
+
+        The insert is attempted inside a SAVEPOINT so a concurrent scrape of the same source
+        racing us to create the same (source_id, external_id) row only aborts that SAVEPOINT,
+        not the whole job's transaction — we then fall back to the update path against the row
+        the other job just committed, instead of crashing on uq_listings_source_external_id.
         """
         now = datetime.now(timezone.utc)
         existing = await self._find_existing(source_id, data.external_id)
@@ -78,11 +84,23 @@ class ListingRepository:
                 last_seen_at=now,
                 last_checked_at=now,
             )
-            self.session.add(listing)
-            await self.session.flush()
-            self._add_snapshot(listing, data, now)
-            return listing, True, None
+            try:
+                async with self.session.begin_nested():
+                    self.session.add(listing)
+                    await self.session.flush()
+            except IntegrityError:
+                existing = await self._find_existing(source_id, data.external_id)
+                if existing is None:
+                    raise
+            else:
+                self._add_snapshot(listing, data, now)
+                return listing, True, None
 
+        return self._apply_update(existing, data, now)
+
+    def _apply_update(
+        self, existing: Listing, data: SourceListing, now: datetime
+    ) -> tuple[Listing, bool, int | None]:
         existing.last_seen_at = now
         existing.last_checked_at = now
         existing.status = ListingStatus.ACTIVE

--- a/tests/unit/test_listing_repository.py
+++ b/tests/unit/test_listing_repository.py
@@ -1,0 +1,86 @@
+import pytest
+from sqlalchemy import func, select
+
+from app.listings.repository import ListingRepository
+from app.models.listing import Listing
+from app.models.snapshot import ListingSnapshot
+from app.sources.base import SourceListing
+from tests.conftest import seed_source
+
+
+def _listing(external_id: str = "42", price: int = 10_000) -> SourceListing:
+    return SourceListing(
+        external_id=external_id,
+        canonical_url=f"https://example.com/{external_id}",
+        title="Test listing",
+        make="Skoda",
+        model="Octavia",
+        production_year=2019,
+        mileage_km=100_000,
+        price=price,
+        currency="EUR",
+    )
+
+
+@pytest.mark.asyncio
+async def test_upsert_listing_creates_new_listing_and_snapshot(session):
+    source = await seed_source(session)
+    repo = ListingRepository(session)
+
+    listing, is_new, previous_price = await repo.upsert_listing(source.id, _listing())
+
+    assert is_new is True
+    assert previous_price is None
+    assert listing.external_id == "42"
+
+    snapshots = await repo.get_history(listing.id)
+    assert len(snapshots) == 1
+
+
+@pytest.mark.asyncio
+async def test_upsert_listing_concurrent_insert_falls_back_to_update(session, monkeypatch):
+    """Reproduces the production race (job 75fdd3e7 on 2026-09-10): two scrape jobs for the same
+    source both call upsert_listing for the same (source_id, external_id) before either has
+    committed, so both see it as "new". Here that's simulated by forcing the first `_find_existing`
+    check to miss a row that (from the DB's point of view) another job has just inserted and
+    committed, so the subsequent INSERT hits uq_listings_source_external_id. The repository must
+    catch that IntegrityError and fall back to updating the row the other job created, rather than
+    letting it propagate and abort the job's session.
+    """
+    source = await seed_source(session)
+    repo = ListingRepository(session)
+
+    other_job_repo = ListingRepository(session)
+    winning_listing, _, _ = await other_job_repo.upsert_listing(source.id, _listing(price=9_000))
+    await session.commit()
+
+    real_find_existing = ListingRepository._find_existing
+    call_count = 0
+
+    async def flaky_find_existing(self, source_id, external_id):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return None
+        return await real_find_existing(self, source_id, external_id)
+
+    monkeypatch.setattr(ListingRepository, "_find_existing", flaky_find_existing)
+
+    listing, is_new, previous_price = await repo.upsert_listing(source.id, _listing(price=10_000))
+
+    assert is_new is False
+    assert listing.id == winning_listing.id
+    assert previous_price == 9_000
+    assert listing.price == 10_000
+
+    await session.commit()
+
+    count = await session.scalar(
+        select(func.count()).select_from(Listing).where(Listing.source_id == source.id, Listing.external_id == "42")
+    )
+    assert count == 1
+
+    snapshot_count = await session.scalar(
+        select(func.count()).select_from(ListingSnapshot).where(ListingSnapshot.listing_id == winning_listing.id)
+    )
+    assert snapshot_count == 2


### PR DESCRIPTION
## Summary
- `ListingRepository.upsert_listing` did a SELECT-then-INSERT with no atomicity guard, so two scrape jobs for the same source (e.g. a manual full-source refresh overlapping another job) could both see an `external_id` as new and race to INSERT it, hitting `uq_listings_source_external_id` and crashing the losing job's session (which then failed again on the subsequent `session.commit()` with `PendingRollbackError`, marking the job FAILED).
- Reproduced in production logs on 2026-09-10 ~07:35:34 UTC (worker service, Railway project "car radar rs"): job `75fdd3e7-7f23-4a52-b5cf-d503a5a09ada` failed with `duplicate key value violates unique constraint "uq_listings_source_external_id"` for `source_id=36aca1a7-fcff-453b-8096-962655065663`, `external_id=29844062`, while another full-source-refresh job for the same source was running concurrently.
- The insert now runs inside a SAVEPOINT (`session.begin_nested()`); if it conflicts, only the SAVEPOINT rolls back (not the whole job's transaction), and the code falls back to updating the row the other job just committed instead of crashing.

## Test plan
- [x] Added `tests/unit/test_listing_repository.py` with a race-simulation test that forces the initial existence check to miss a row another "job" already committed, verifying the repository falls back to an update (one row, one extra snapshot, correct `previous_price`) instead of raising `IntegrityError`.
- [x] `pytest tests/` — 202 passed
- [x] `ruff check` / `mypy` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)