### PR TITLE
Retry+skip unparseable search pages, fix worker rollback race

### DIFF
--- a/app/scraping/fetch_outcome.py
+++ b/app/scraping/fetch_outcome.py
@@ -27,6 +27,10 @@ class FetchOutcome(str, enum.Enum):
     # markup/JSON shape). Classified anyway so it shows up in per-job stats instead of crashing
     # the job unclassified.
     PARSER_ERROR = "parser_error"
+    # A page that failed to parse twice in a row (see PolovniAutomobiliSource._iter_search_pages)
+    # was skipped rather than aborting the whole crawl. Not block-like and not itself a fetch
+    # outcome — recorded once per abandoned page so job stats show how many pages were lost.
+    PAGE_SKIPPED = "page_skipped"
 
 
 BLOCK_LIKE = frozenset(

--- a/app/scraping/pipeline.py
+++ b/app/scraping/pipeline.py
@@ -11,7 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.listings.repository import ListingRepository
 from app.models.source import Source
-from app.scraping.fetch_outcome import FetchBlockedError, OutcomeCounter, ParserError
+from app.scraping.fetch_outcome import FetchBlockedError, FetchOutcome, OutcomeCounter, ParserError
 from app.scraping.proxy import ProxyProvider
 from app.search.query import SearchQuery
 from app.sources.base import CarSource, SourceListing
@@ -26,6 +26,11 @@ class ScrapeStats:
     listings_removed: int = 0
     outcome_counts: dict[str, int] = field(default_factory=dict)
     blocked: bool = False
+    # Set when `blocked` was caused by a hard abort (FetchBlockedError/ParserError bubbling out of
+    # the adapter) — the message that explains why, since `outcome_counts` alone only says how many
+    # of which outcome, not what actually happened. Unset for a skipped-page-only partial run,
+    # where per-page detail already reads out of outcome_counts (parser_error/page_skipped counts).
+    error_detail: str | None = None
     seen_external_ids: set[str] = field(default_factory=set)
     # Per-listing detail the aggregate counts above don't carry — consumed by
     # app/notifications/matching.py (issues #21/#26) to generate NEW_MATCH/PRICE_DROP events
@@ -96,11 +101,19 @@ async def run_scrape(
                 stats.listings_updated += 1
                 if previous_price is not None and previous_price > listing.price:
                     stats.price_drops.append((listing.id, previous_price, listing.price))
-    except (FetchBlockedError, ParserError):
+    except (FetchBlockedError, ParserError) as exc:
         # Stop pagination early but keep whatever was already upserted this run — a partial
         # result is more useful than losing it. FetchBlockedError means the source just told us
-        # to back off (burning further proxy/direct requests would be wasteful); ParserError means
-        # one page came back in an unexpected shape, which a retry of the same page won't fix.
+        # to back off (burning further proxy/direct requests would be wasteful); ParserError here
+        # means the adapter itself gave up on retrying (see PolovniAutomobiliSource._fetch_listing
+        # /fetch_listing, which still raise immediately — only the search-page loop retries and
+        # skips instead of raising).
+        stats.blocked = True
+        stats.error_detail = str(exc)
+
+    if counter.as_dict().get(FetchOutcome.PAGE_SKIPPED.value, 0) > 0:
+        # A skipped page means this run isn't a complete picture of the source even though the
+        # crawl otherwise ran to completion — same reasoning as the abort-mid-crawl case above.
         stats.blocked = True
 
     if mark_removed and not stats.blocked and stats.listings_seen > 0:

--- a/app/scraping/worker.py
+++ b/app/scraping/worker.py
@@ -58,6 +58,12 @@ async def run_scrape_job(ctx: dict[str, Any], job_id: str) -> None:
                 mark_removed=job.job_type == ScrapeJobType.FULL_SOURCE_REFRESH,
             )
         except Exception as exc:  # noqa: BLE001 - persisted below, not swallowed silently
+            # A failure inside run_scrape (e.g. an IntegrityError from a concurrent scrape of the
+            # same source racing on the same new listing) leaves the session's transaction needing
+            # an explicit rollback before it can be used again — without this, the commit() below
+            # itself raises PendingRollbackError, so the real failure never gets recorded and the
+            # job is left stuck instead of FAILED.
+            await session.rollback()
             job.status = ScrapeJobStatus.FAILED
             job.error = {"type": type(exc).__name__, "message": str(exc)}
             job.finished_at = datetime.now(timezone.utc)
@@ -76,6 +82,7 @@ async def run_scrape_job(ctx: dict[str, Any], job_id: str) -> None:
             "listings_updated": stats.listings_updated,
             "listings_removed": stats.listings_removed,
             "outcome_counts": stats.outcome_counts,
+            "error_detail": stats.error_detail,
         }
         job.finished_at = datetime.now(timezone.utc)
         await session.commit()

--- a/app/sources/polovniautomobili/adapter.py
+++ b/app/sources/polovniautomobili/adapter.py
@@ -125,12 +125,34 @@ class PolovniAutomobiliSource:
         result = await self.fetcher.fetch(url)
         return raise_for_blocked(result, url)
 
+    async def _fetch_search_page(self, url: str) -> tuple[list[SourceListing], int] | None:
+        """One fetch+parse attempt for a search page. Returns None (rather than raising) on a
+        parse failure, so `_iter_search_pages` can retry or skip the page instead of aborting the
+        whole crawl — a fetch failure (FetchBlockedError, or the RuntimeError raise_for_blocked
+        raises for TIMEOUT/SERVER_ERROR) still propagates normally, since those aren't
+        page-specific and retrying won't help.
+        """
+        html = await self._fetch(url)
+        try:
+            return self._guard_parse(self.parse_search_page, html)
+        except ParserError:
+            return None
+
     async def _iter_search_pages(self, query: SearchQuery) -> AsyncIterator[SourceListing]:
         page = 1
         while page <= self.max_pages:
             url = self.build_search_url(query, page)
-            html = await self._fetch(url)
-            listings, page_count = self._guard_parse(self.parse_search_page, html)
+            result = await self._fetch_search_page(url)
+            if result is None:
+                # One retry: a parse failure could be a transient odd response. A second
+                # consecutive failure means this page really can't be parsed — skip it and keep
+                # crawling the rest of the source rather than losing everything after it.
+                result = await self._fetch_search_page(url)
+            if result is None:
+                self._record(FetchOutcome.PAGE_SKIPPED)
+                page += 1
+                continue
+            listings, page_count = result
             for listing in listings:
                 yield listing
             if page >= page_count:

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -68,6 +68,7 @@ export interface ScrapeJobStats {
   listings_updated?: number
   listings_removed?: number
   outcome_counts?: Record<string, number>
+  error_detail?: string | null
 }
 
 export interface ListJobsFilters {

--- a/frontend/src/pages/AdminJobsPage.tsx
+++ b/frontend/src/pages/AdminJobsPage.tsx
@@ -60,7 +60,16 @@ function describeJobStats(stats: Record<string, unknown> | null): string {
   const created = s.listings_created ?? 0
   const updated = s.listings_updated ?? 0
   const removed = s.listings_removed ?? 0
-  return `всего ${seen}, новых ${created}, обновлено ${updated}, удалено ${removed}`
+  const parts = [`всего ${seen}, новых ${created}, обновлено ${updated}, удалено ${removed}`]
+
+  const outcomes = Object.entries(s.outcome_counts ?? {}).filter(([, count]) => count > 0)
+  if (outcomes.length > 0) {
+    parts.push(outcomes.map(([outcome, count]) => `${outcome}: ${count}`).join(', '))
+  }
+  if (s.error_detail) {
+    parts.push(s.error_detail)
+  }
+  return parts.join(' — ')
 }
 
 export function AdminJobsPage() {

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -91,6 +91,7 @@ async def test_run_scrape_persists_partial_results_when_blocked_mid_crawl(sessio
     assert stats.listings_updated == 0
     assert stats.blocked is True
     assert stats.outcome_counts == {"success": 1, "forbidden": 1}
+    assert stats.error_detail == "Fetch blocked: forbidden"
 
     persisted = (await session.execute(select(Listing))).scalars().all()
     assert len(persisted) == 2
@@ -104,9 +105,54 @@ async def test_run_scrape_persists_partial_results_on_parser_error_mid_crawl(ses
     assert stats.listings_seen == 1
     assert stats.blocked is True
     assert stats.outcome_counts == {"success": 1, "parser_error": 1}
+    assert stats.error_detail == "Parser error: unexpected page shape"
 
     persisted = (await session.execute(select(Listing))).scalars().all()
     assert len(persisted) == 1
+
+
+class StubPageSkippedAdapter:
+    """Mirrors PolovniAutomobiliSource._iter_search_pages after a page fails to parse twice: it
+    records PARSER_ERROR/PAGE_SKIPPED via the outcome sink but keeps crawling and yielding
+    listings instead of raising — run_scrape should still treat the run as incomplete (skip
+    mark_removed, end up PARTIAL) without losing the listings gathered after the skipped page.
+    """
+
+    source_code = "stub_source"
+    display_name = "Stub Source"
+    domain = "stub.example.com"
+    country = "RS"
+
+    def __init__(self, max_pages=5, proxy_provider=None, outcome_sink=None):
+        self.outcome_sink = outcome_sink
+
+    async def search_with_data(self, query: SearchQuery) -> AsyncIterator[SourceListing]:
+        if self.outcome_sink:
+            self.outcome_sink(FetchOutcome.SUCCESS)
+        yield _listing("1", 10_000)
+        if self.outcome_sink:
+            self.outcome_sink(FetchOutcome.PARSER_ERROR)
+            self.outcome_sink(FetchOutcome.PARSER_ERROR)
+            self.outcome_sink(FetchOutcome.PAGE_SKIPPED)
+            self.outcome_sink(FetchOutcome.SUCCESS)
+        yield _listing("2", 12_000)
+
+
+async def test_run_scrape_marks_blocked_when_a_page_was_skipped(session, monkeypatch):
+    monkeypatch.setitem(registry.SOURCE_REGISTRY, "stub_source", StubPageSkippedAdapter)
+
+    stats = await run_scrape(session, source_code="stub_source", query=SearchQuery(), mark_removed=True)
+
+    # Unlike a hard abort, the crawl ran to completion — both listings persisted — but the run is
+    # still not a clean full pass, so it's flagged the same way as an aborted one.
+    assert stats.listings_seen == 2
+    assert stats.blocked is True
+    assert stats.listings_removed == 0
+    assert stats.error_detail is None
+    assert stats.outcome_counts["page_skipped"] == 1
+
+    persisted = (await session.execute(select(Listing))).scalars().all()
+    assert len(persisted) == 2
 
 
 async def test_run_scrape_marks_missing_listings_removed_when_mark_removed_is_true(session, monkeypatch):

--- a/tests/unit/test_polovni_adapter.py
+++ b/tests/unit/test_polovni_adapter.py
@@ -5,7 +5,7 @@ import requests
 
 from app.scraping.fetch_outcome import FetchBlockedError, FetchOutcome, ParserError
 from app.scraping.proxy import FetchError, FetchMetrics, ProxyEndpoint
-from app.sources.base import SourceListingRef
+from app.sources.base import SourceListing, SourceListingRef
 from app.sources.polovniautomobili.adapter import PolovniAutomobiliSource
 
 FIXTURES = Path(__file__).parent.parent / "fixtures" / "polovniautomobili"
@@ -173,6 +173,72 @@ async def test_fetch_records_outcomes_via_sink(monkeypatch):
     await adapter._fetch("https://example.com/search")
 
     assert outcomes == [FetchOutcome.SUCCESS]
+
+
+async def test_iter_search_pages_retries_once_then_skips_unparseable_page(monkeypatch):
+    from app.search.query import SearchQuery
+
+    outcomes: list[FetchOutcome] = []
+    adapter = PolovniAutomobiliSource(proxy_provider=FakeProxyProvider(), outcome_sink=outcomes.append, max_pages=3)
+
+    parsed_urls: list[str] = []
+
+    async def fake_fetch(url: str) -> str:
+        return url
+
+    def fake_parse(html: str) -> tuple[list, int]:
+        parsed_urls.append(html)
+        if "page=1&" in html:
+            raise ValueError("unexpected page shape")
+        return [], 2
+
+    monkeypatch.setattr(adapter, "_fetch", fake_fetch)
+    monkeypatch.setattr(adapter, "parse_search_page", fake_parse)
+
+    results = [listing async for listing in adapter.search_with_data(SearchQuery())]
+
+    assert results == []
+    # page 1: fetched and parsed twice (initial attempt + one retry), both fail and it's skipped;
+    # page 2: fetched and parsed once, succeeds with page_count=2 so the crawl stops there.
+    assert sum("page=1&" in url for url in parsed_urls) == 2
+    assert sum("page=2&" in url for url in parsed_urls) == 1
+    assert outcomes == [
+        FetchOutcome.PARSER_ERROR,
+        FetchOutcome.PARSER_ERROR,
+        FetchOutcome.PAGE_SKIPPED,
+    ]
+
+
+async def test_iter_search_pages_recovers_if_retry_parses_successfully(monkeypatch):
+    from app.search.query import SearchQuery
+
+    outcomes: list[FetchOutcome] = []
+    adapter = PolovniAutomobiliSource(proxy_provider=FakeProxyProvider(), outcome_sink=outcomes.append, max_pages=3)
+
+    attempts: dict[str, int] = {}
+    listing = SourceListing(
+        external_id="1", canonical_url="https://x/1", title="x", make="Skoda", model="Octavia",
+        production_year=2019, mileage_km=1, price=1, currency="EUR",
+    )
+
+    async def fake_fetch(url: str) -> str:
+        return url
+
+    def fake_parse(html: str) -> tuple[list, int]:
+        attempts[html] = attempts.get(html, 0) + 1
+        if attempts[html] == 1:
+            raise ValueError("transient")
+        return [listing], 1
+
+    monkeypatch.setattr(adapter, "_fetch", fake_fetch)
+    monkeypatch.setattr(adapter, "parse_search_page", fake_parse)
+
+    results = [item async for item in adapter.search_with_data(SearchQuery())]
+
+    # The retry succeeded, so the page is NOT skipped: its listing is yielded and the loop stops
+    # at page_count=1 instead of continuing — a transient failure shouldn't cost the crawl a page.
+    assert results == [listing]
+    assert outcomes == [FetchOutcome.PARSER_ERROR]
 
 
 async def test_fetch_listing_records_and_raises_parser_error_on_malformed_page(monkeypatch):

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -76,6 +76,7 @@ async def test_run_scrape_job_marks_completed_on_success(worker_session_factory,
             "listings_updated": 1,
             "listings_removed": 0,
             "outcome_counts": {"success": 3},
+            "error_detail": None,
         }
         assert job.started_at is not None
         assert job.finished_at is not None
@@ -113,6 +114,30 @@ async def test_run_scrape_job_marks_failed_on_exception(worker_session_factory, 
         job = await session.get(ScrapeJob, job_id)
         assert job.status == ScrapeJobStatus.FAILED
         assert job.error == {"type": "RuntimeError", "message": "boom"}
+
+
+async def test_run_scrape_job_marks_failed_when_session_needs_rollback(worker_session_factory, monkeypatch):
+    """Mirrors a concurrent-scrape race in ListingRepository.upsert_listing: run_scrape leaves the
+    session's transaction needing an explicit rollback (e.g. after a flush-time IntegrityError)
+    before raising. Without a rollback first, the except block's own commit() would itself raise
+    PendingRollbackError and the job would never get marked FAILED — see app/scraping/worker.py.
+    """
+    job_id = await _seed_job(worker_session_factory)
+
+    async def fake_run_scrape(session, source_code, query, max_pages=5, proxy_provider=None, mark_removed=False):
+        session.add(Source(code="polovniautomobili", name="dup", domain="dup.example.com", country="RS"))
+        await session.flush()  # raises IntegrityError: code is unique
+
+    monkeypatch.setattr(worker_module, "run_scrape", fake_run_scrape)
+
+    ctx = {"session_factory": worker_session_factory, "proxy_provider": NullProxyProvider()}
+    with pytest.raises(Exception):
+        await worker_module.run_scrape_job(ctx, str(job_id))
+
+    async with worker_session_factory() as session:
+        job = await session.get(ScrapeJob, job_id)
+        assert job.status == ScrapeJobStatus.FAILED
+        assert job.finished_at is not None
 
 
 async def test_run_scrape_job_passes_stored_query_and_max_pages_to_run_scrape(worker_session_factory, monkeypatch):


### PR DESCRIPTION
## Summary
- `PolovniAutomobiliSource._iter_search_pages` now retries a search page once on `ParserError`, and skips it (recording `FetchOutcome.PAGE_SKIPPED`) instead of aborting the entire crawl — a single bad page no longer kills a full-source-refresh partway through (this is what happened to the job investigated in this session: it stopped at 543/~3000 listings after one page failed to parse).
- `run_scrape` still treats a run with any skipped page as incomplete (`stats.blocked = True`), so `mark_removed` is still safely skipped and the job still shows `PARTIAL`.
- A hard abort (`FetchBlockedError`/`ParserError` bubbling out) now records the actual exception text in `ScrapeStats.error_detail` → `job.stats.error_detail`, and the admin jobs table surfaces `outcome_counts` + this detail so a partial/failed run is diagnosable without querying prod.
- `worker.py`'s failure handler now calls `session.rollback()` before re-committing on exception — previously, a flush-time `IntegrityError` (e.g. two concurrent scrapes of the same source racing to insert the same new listing) left the session broken, so the follow-up commit that records `FAILED` also raised, and the job was left stuck instead of recording the real failure.

## Test plan
- [x] `pytest tests/` (202 passed)
- [x] `ruff check app tests` / `mypy app` clean
- [x] `tsc -b` clean (frontend)
- [x] New tests: adapter retry-then-skip and retry-then-recover, pipeline skip-mid-crawl gating of `mark_removed`, worker rollback-then-FAILED reproduction

🤖 Generated with [Claude Code](https://claude.com/claude-code)