### PR TITLE
Capture and translate equipment (Oprema) for filtering

### DIFF
--- a/app/listings/repository.py
+++ b/app/listings/repository.py
@@ -79,6 +79,7 @@ class ListingRepository:
                 location=data.location,
                 seller_type=data.seller_type,
                 image_url=data.image_url,
+                equipment=data.equipment,
                 status=ListingStatus.ACTIVE,
                 first_seen_at=now,
                 last_seen_at=now,
@@ -121,6 +122,12 @@ class ListingRepository:
             self._add_snapshot(existing, data, now)
 
         return existing, False, previous_price
+
+    def set_equipment(self, listing: Listing, equipment: list[str]) -> None:
+        """Called once, right after a new listing is created, with equipment parsed from its
+        detail page (search-page results don't carry it) — see app/scraping/pipeline.py.
+        """
+        listing.equipment = equipment
 
     async def mark_missing_as_removed(self, source_id: uuid.UUID, seen_external_ids: set[str]) -> int:
         """Mark active listings for a source that were not encountered in the latest crawl as

--- a/app/models/listing.py
+++ b/app/models/listing.py
@@ -2,7 +2,8 @@ import enum
 import uuid
 from datetime import datetime
 
-from sqlalchemy import DateTime, Enum, ForeignKey, Integer, String, Uuid
+from sqlalchemy import JSON, DateTime, Enum, ForeignKey, Index, Integer, String, Uuid
+from sqlalchemy.dialects.postgresql import ARRAY
 from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.schema import UniqueConstraint
 
@@ -22,7 +23,10 @@ class Listing(UUIDPkMixin, TimestampMixin, Base):
     """
 
     __tablename__ = "listings"
-    __table_args__ = (UniqueConstraint("source_id", "external_id", name="uq_listings_source_external_id"),)
+    __table_args__ = (
+        UniqueConstraint("source_id", "external_id", name="uq_listings_source_external_id"),
+        Index("ix_listings_equipment", "equipment", postgresql_using="gin"),
+    )
 
     source_id: Mapped[uuid.UUID] = mapped_column(Uuid, ForeignKey("sources.id"), nullable=False)
     external_id: Mapped[str] = mapped_column(String(64), nullable=False)
@@ -50,6 +54,16 @@ class Listing(UUIDPkMixin, TimestampMixin, Base):
     seller_type: Mapped[str | None] = mapped_column(String(32), nullable=True)
     seller_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
     image_url: Mapped[str | None] = mapped_column(String(1024), nullable=True)
+
+    # Backfilled once from the listing detail page the first time it's seen (search-page results
+    # don't carry it) — see app/scraping/pipeline.py's new-listing enrichment step. Normalized
+    # slugs from app/sources/polovniautomobili/mapper.py's equipment vocabulary. Native ARRAY (with
+    # a GIN index below) for `@>` containment filtering on Postgres; the sqlite variant is only
+    # there so the test suite's in-memory sqlite db (see tests/conftest.py) can create this table —
+    # equipment filtering itself is Postgres-only, same as the GIN index.
+    equipment: Mapped[list[str]] = mapped_column(
+        ARRAY(String).with_variant(JSON(), "sqlite"), default=list, nullable=False
+    )
 
     status: Mapped[ListingStatus] = mapped_column(
         Enum(ListingStatus, native_enum=False, length=16), default=ListingStatus.ACTIVE, nullable=False

--- a/app/scraping/pipeline.py
+++ b/app/scraping/pipeline.py
@@ -10,11 +10,12 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.listings.repository import ListingRepository
+from app.models.listing import Listing
 from app.models.source import Source
 from app.scraping.fetch_outcome import FetchBlockedError, OutcomeCounter, ParserError
 from app.scraping.proxy import ProxyProvider
 from app.search.query import SearchQuery
-from app.sources.base import CarSource, SourceListing
+from app.sources.base import CarSource, SourceListing, SourceListingRef
 from app.sources.registry import get_source_adapter
 
 
@@ -59,6 +60,21 @@ async def _search_listings(adapter: CarSource, query: SearchQuery) -> AsyncItera
         yield await adapter.fetch_listing(ref)
 
 
+async def _enrich_with_equipment(adapter: CarSource, repository: ListingRepository, listing: Listing) -> None:
+    """Search-page results don't carry `equipment` (see mapper.py's docstring on the search vs.
+    detail page JSON shapes), so a brand-new listing gets one extra detail-page fetch here to
+    backfill it. Only done once, on creation — a listing's equipment doesn't change over its
+    lifetime, so re-crawls of an already-known listing skip this and stay cheap.
+    """
+    ref = SourceListingRef(external_id=listing.external_id, url=listing.canonical_url)
+    try:
+        detail = await adapter.fetch_listing(ref)
+    except (FetchBlockedError, ParserError):
+        return
+    if detail.equipment:
+        repository.set_equipment(listing, detail.equipment)
+
+
 async def run_scrape(
     session: AsyncSession,
     source_code: str,
@@ -92,6 +108,7 @@ async def run_scrape(
             if is_new:
                 stats.listings_created += 1
                 stats.new_listing_ids.append(listing.id)
+                await _enrich_with_equipment(adapter, repository, listing)
             else:
                 stats.listings_updated += 1
                 if previous_price is not None and previous_price > listing.price:

--- a/app/search/query.py
+++ b/app/search/query.py
@@ -30,6 +30,7 @@ class SearchQuery(BaseModel):
     fuel_types: list[str] | None = None
     transmissions: list[str] | None = None
     body_types: list[str] | None = None
+    equipment: list[str] | None = None
     location: str | None = None
 
     def stable_hash(self) -> str:

--- a/app/search/query.py
+++ b/app/search/query.py
@@ -51,6 +51,8 @@ class SearchQuery(BaseModel):
             parts.append(f"{self.year_min or '…'}–{self.year_max or '…'}")
         if self.price_min or self.price_max:
             parts.append(f"€{self.price_min or '…'}–{self.price_max or '…'}")
+        if self.equipment:
+            parts.append(f"+{len(self.equipment)} опций")
         return ", ".join(parts) if parts else "все объявления"
 
 

--- a/app/search/service.py
+++ b/app/search/service.py
@@ -88,6 +88,8 @@ def _apply_filters(stmt: Select, query: SearchQuery) -> Select:
         stmt = stmt.where(Listing.transmission.in_(query.transmissions))
     if query.body_types:
         stmt = stmt.where(Listing.body_type.in_(query.body_types))
+    if query.equipment:
+        stmt = stmt.where(Listing.equipment.contains(query.equipment))
     if query.location:
         stmt = stmt.where(func.lower(Listing.location) == query.location.lower())
     return stmt

--- a/app/sources/base.py
+++ b/app/sources/base.py
@@ -44,6 +44,7 @@ class SourceListing:
     location: str | None = None
     seller_type: str | None = None
     image_url: str | None = None
+    equipment: list[str] = field(default_factory=list)
     raw: dict[str, Any] = field(default_factory=dict)
 
 

--- a/app/sources/polovniautomobili/mapper.py
+++ b/app/sources/polovniautomobili/mapper.py
@@ -43,6 +43,111 @@ _BODY_TYPE_NORMALIZED = {
     "Monovolumen (MiniVan)": "minivan",
 }
 
+# The `equipment` list only appears in the listing detail page's JSON (`productData.equipment`,
+# see map_product_data below) — it's a closed set of checkboxes the site itself offers when
+# sellers create a listing, enumerated here from real fixtures/listings rather than derived
+# programmatically. Unrecognized values pass through untranslated (see normalize_equipment)
+# instead of being dropped, so a new checkbox the site adds later doesn't silently disappear.
+_EQUIPMENT_NORMALIZED = {
+    "Metalik boja": "metallic_paint",
+    "Branici u boji auta": "body_colored_bumpers",
+    "Servo volan": "power_steering",
+    "Multifunkcionalni volan": "multifunction_steering_wheel",
+    "Tempomat": "cruise_control",
+    "Daljinsko zaključavanje": "remote_central_locking",
+    "Putni računar": "trip_computer",
+    "Šiber": "sunroof",
+    "Panoramski krov": "panoramic_roof",
+    "Tonirana stakla": "tinted_windows",
+    "Električni podizači prozora": "power_windows",
+    "Električni retrovizori": "power_mirrors",
+    "Grejači retrovizora": "heated_mirrors",
+    "Sedišta podesiva po visini": "height_adjustable_seats",
+    "Elektro podesiva sedišta": "power_adjustable_seats",
+    "Grejanje sedišta": "heated_seats",
+    "Svetla za maglu": "fog_lights",
+    "Xenon svetla": "xenon_headlights",
+    "Senzori za svetla": "light_sensor",
+    "Senzori za kišu": "rain_sensor",
+    "Parking senzori": "parking_sensors",
+    "Webasto": "auxiliary_heater",
+    "Krovni nosač": "roof_rack",
+    "Kuka za vuču": "tow_hook",
+    "Aluminijumske felne": "alloy_wheels",
+    "Navigacija": "navigation_system",
+    "Bluetooth": "bluetooth",
+    "Radio/Kasetofon": "radio_cassette",
+    "Radio CD": "radio_cd",
+    "CD changer": "cd_changer",
+    "DVD/TV": "dvd_tv",
+    "LED prednja svetla": "led_headlights",
+    "Grejači vetrobranskog stakla": "heated_windshield",
+    "LED zadnja svetla": "led_taillights",
+    "Naslon za ruku": "armrest",
+    "Adaptivni tempomat": "adaptive_cruise_control",
+    "Automatsko parkiranje": "automatic_parking",
+    "Kamera": "camera",
+    "Hands free": "hands_free",
+    "Adaptivna svetla": "adaptive_headlights",
+    "Head-up display": "head_up_display",
+    "ISOFIX sistem": "isofix",
+    "Start-stop sistem": "start_stop_system",
+    "Prednja noćna kamera": "front_night_vision_camera",
+    "Multimedija": "multimedia_system",
+    "Glasovne komande": "voice_control",
+    "Masažna sedišta": "massage_seats",
+    "Elektrosklopivi retrovizori": "power_folding_mirrors",
+    "Memorija sedišta": "seat_memory",
+    "Sportska sedišta": "sport_seats",
+    "Sportsko vešanje": "sport_suspension",
+    "DPF filter": "dpf_filter",
+    "Dnevna svetla": "daytime_running_lights",
+    "Torba za skije": "ski_bag",
+    "Upravljanje na sva četiri točka": "four_wheel_steering",
+    "Brisači prednjih farova": "headlight_washers",
+    "360 kamera": "camera_360",
+    "Fabrički ugrađeno dečije sedište": "factory_child_seat",
+    "Ekran na dodir": "touchscreen",
+    "Kožni volan": "leather_steering_wheel",
+    "Volan u kombinaciji drvo/koža": "wood_leather_steering_wheel",
+    "Grejanje volana": "heated_steering_wheel",
+    "Električno zatvaranje prtljažnika": "power_trunk_closing",
+    "Zavesice na zadnjim prozorima": "rear_window_curtains",
+    "Privlačenje vrata pri zatvaranju": "soft_close_doors",
+    "USB": "usb",
+    "Paljenje bez ključa": "keyless_start",
+    "Hard disk": "hard_disk",
+    "Ventilacija sedišta": "ventilated_seats",
+    "Vazdušno vešanje": "air_suspension",
+    "Ambijentalno osvetljenje": "ambient_lighting",
+    "Subwoofer": "subwoofer",
+    "MP3": "mp3",
+    "Digitalni radio": "digital_radio",
+    "Utičnica od 12V": "power_outlet_12v",
+    "Električno otvaranje prtljažnika": "power_trunk_opening",
+    "Zaključavanje diferencijala": "differential_lock",
+    "Otvor za skije": "ski_hatch",
+    "Podešavanje volana po visini": "steering_wheel_height_adjustment",
+    "Ostava sa hlađenjem": "cooled_glovebox",
+    "Držači za čaše": "cup_holders",
+    "Ručice za menjanje brzina na volanu": "paddle_shifters",
+    "Retrovizor se obara pri rikvercu": "mirror_tilt_in_reverse",
+    "Automatsko zatamnjivanje retrovizora": "auto_dimming_mirror",
+    "Rezervni točak": "spare_wheel",
+    "Indikator niskog pritiska u gumama": "tire_pressure_monitor",
+    "Keramičke kočnice": "ceramic_brakes",
+    "Elektronska ručna kočnica": "electronic_parking_brake",
+    "Asistencija za kretanje na uzbrdici": "hill_start_assist",
+    "AUX konekcija": "aux_input",
+    "Modovi vožnje": "drive_mode_selector",
+    "Postolje za bežično punjenje telefona": "wireless_phone_charging",
+    "Apple CarPlay": "apple_carplay",
+    "Android Auto": "android_auto",
+    "Autonomna vožnja": "autonomous_driving",
+    "Virtuelna tabla": "digital_instrument_cluster",
+    "Matrix farovi": "matrix_headlights",
+}
+
 
 def normalize_fuel_type(raw: str | None) -> str | None:
     if not raw:
@@ -65,6 +170,12 @@ def normalize_body_type(raw: str | None) -> str | None:
     if not raw:
         return None
     return _BODY_TYPE_NORMALIZED.get(raw, raw)
+
+
+def normalize_equipment(raw: list[str] | None) -> list[str]:
+    if not raw:
+        return []
+    return [_EQUIPMENT_NORMALIZED.get(item, item) for item in raw]
 
 
 def slugify(text: str) -> str:
@@ -138,5 +249,6 @@ def map_product_data(raw: dict, canonical_path: str | None = None) -> SourceList
         location=raw.get("owner", {}).get("city"),
         seller_type="dealer" if "ROLE_DEALER" in raw.get("owner", {}).get("roles", []) else "private",
         image_url=_primary_image_url(raw.get("images")),
+        equipment=normalize_equipment(raw.get("equipment")),
         raw=raw,
     )

--- a/frontend/src/lib/search.ts
+++ b/frontend/src/lib/search.ts
@@ -17,6 +17,7 @@ export interface SearchQuery {
   fuel_types?: string[]
   transmissions?: string[]
   body_types?: string[]
+  equipment?: string[]
   location?: string
 }
 
@@ -27,6 +28,7 @@ export function describeQuery(query: SearchQuery): string {
   if (Array.isArray(query.models) && query.models.length) parts.push((query.models as string[]).join('/'))
   if (query.year_min || query.year_max) parts.push(`${query.year_min ?? '…'}–${query.year_max ?? '…'}`)
   if (query.price_min || query.price_max) parts.push(`€${query.price_min ?? '…'}–${query.price_max ?? '…'}`)
+  if (query.equipment?.length) parts.push(`+${query.equipment.length} опций`)
   return parts.length ? parts.join(', ') : 'Все объявления'
 }
 

--- a/frontend/src/search/EquipmentFilter.tsx
+++ b/frontend/src/search/EquipmentFilter.tsx
@@ -1,0 +1,113 @@
+import { useMemo, useState } from 'react'
+import { EQUIPMENT_CATEGORIES, EQUIPMENT_POPULAR } from './constants'
+
+const labelClass = 'mb-1 block text-xs font-medium text-slate-600'
+
+function Chip({ label, active, onClick }: { label: string; active: boolean; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={
+        'rounded-full border px-2.5 py-1 text-xs font-medium transition-colors ' +
+        (active
+          ? 'border-slate-900 bg-slate-900 text-white'
+          : 'border-slate-300 text-slate-700 hover:border-slate-400')
+      }
+    >
+      {label}
+    </button>
+  )
+}
+
+export function EquipmentFilter({
+  selected,
+  onChange,
+}: {
+  selected: string[] | undefined
+  onChange: (next: string[] | undefined) => void
+}) {
+  const [expanded, setExpanded] = useState(false)
+  const [search, setSearch] = useState('')
+  const current = selected ?? []
+
+  function toggle(value: string) {
+    const next = current.includes(value) ? current.filter((v) => v !== value) : [...current, value]
+    onChange(next.length > 0 ? next : undefined)
+  }
+
+  const filteredCategories = useMemo(() => {
+    const q = search.trim().toLowerCase()
+    if (!q) return EQUIPMENT_CATEGORIES
+    return EQUIPMENT_CATEGORIES.map((group) => ({
+      ...group,
+      options: group.options.filter((o) => o.label.toLowerCase().includes(q)),
+    })).filter((group) => group.options.length > 0)
+  }, [search])
+
+  // Selected features outside the popular set stay visible as their own chips even when
+  // collapsed, so opening a saved search with an unusual feature doesn't look like it lost it.
+  const extraSelected = current.filter((v) => !EQUIPMENT_POPULAR.some((p) => p.value === v))
+  const extraSelectedLabels = extraSelected.map(
+    (value) => EQUIPMENT_CATEGORIES.flatMap((g) => g.options).find((o) => o.value === value)?.label ?? value
+  )
+
+  return (
+    <div>
+      <span className={labelClass}>Оснащение</span>
+      <div className="flex flex-wrap gap-1.5">
+        {EQUIPMENT_POPULAR.map((option) => (
+          <Chip
+            key={option.value}
+            label={option.label}
+            active={current.includes(option.value)}
+            onClick={() => toggle(option.value)}
+          />
+        ))}
+        {extraSelected.map((value, i) => (
+          <Chip key={value} label={extraSelectedLabels[i]} active onClick={() => toggle(value)} />
+        ))}
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          className="rounded-full border border-dashed border-slate-300 px-2.5 py-1 text-xs font-medium text-slate-500 hover:border-slate-400"
+        >
+          {expanded ? 'Свернуть' : 'Ещё опции…'}
+        </button>
+      </div>
+
+      {expanded && (
+        <div className="mt-3 rounded-md border border-slate-200 p-3">
+          <input
+            type="text"
+            placeholder="Поиск по опциям…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="mb-3 w-full rounded-md border border-slate-300 px-2.5 py-1.5 text-sm text-slate-900 shadow-sm focus:border-slate-500 focus:outline-none focus:ring-1 focus:ring-slate-500"
+          />
+          <div className="max-h-72 space-y-3 overflow-y-auto pr-1">
+            {filteredCategories.map((group) => (
+              <div key={group.category}>
+                <div className="mb-1 text-xs font-semibold text-slate-500">{group.category}</div>
+                <div className="flex flex-wrap gap-x-3 gap-y-1">
+                  {group.options.map((option) => (
+                    <label key={option.value} className="flex items-center gap-1 text-sm text-slate-700">
+                      <input
+                        type="checkbox"
+                        checked={current.includes(option.value)}
+                        onChange={() => toggle(option.value)}
+                        className="rounded border-slate-300"
+                      />
+                      {option.label}
+                    </label>
+                  ))}
+                </div>
+              </div>
+            ))}
+            {filteredCategories.length === 0 && <div className="text-sm text-slate-400">Ничего не найдено</div>}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/search/SearchFilters.tsx
+++ b/frontend/src/search/SearchFilters.tsx
@@ -1,6 +1,7 @@
 import type { SearchQuery } from '../lib/search'
 import { useVehicleMakes } from './useVehicleMakes'
 import { BODY_TYPE_OPTIONS, FUEL_TYPE_OPTIONS, TRANSMISSION_OPTIONS } from './constants'
+import { EquipmentFilter } from './EquipmentFilter'
 
 const inputClass =
   'w-full rounded-md border border-slate-300 px-2.5 py-1.5 text-sm text-slate-900 shadow-sm focus:border-slate-500 focus:outline-none focus:ring-1 focus:ring-slate-500'
@@ -210,6 +211,11 @@ export function SearchFilters({
           onChange={(v) => onChange({ ...value, body_types: v })}
         />
       </div>
+
+      <EquipmentFilter
+        selected={value.equipment}
+        onChange={(v) => onChange({ ...value, equipment: v })}
+      />
 
       <button
         type="submit"

--- a/frontend/src/search/constants.ts
+++ b/frontend/src/search/constants.ts
@@ -25,5 +25,165 @@ export const BODY_TYPE_OPTIONS = [
   { value: 'minivan', label: 'Минивэн' },
 ] as const
 
+// Canonical values normalized by app/sources/polovniautomobili/mapper.py's
+// _EQUIPMENT_NORMALIZED — kept in sync manually, same as the option lists above.
+export const EQUIPMENT_POPULAR = [
+  { value: 'apple_carplay', label: 'Apple CarPlay' },
+  { value: 'android_auto', label: 'Android Auto' },
+  { value: 'adaptive_cruise_control', label: 'Адаптивный круиз-контроль' },
+  { value: 'navigation_system', label: 'Навигация' },
+  { value: 'panoramic_roof', label: 'Панорамная крыша' },
+  { value: 'heated_seats', label: 'Подогрев сидений' },
+  { value: 'parking_sensors', label: 'Парктроник' },
+  { value: 'camera', label: 'Камера' },
+  { value: 'alloy_wheels', label: 'Легкосплавные диски' },
+  { value: 'keyless_start', label: 'Запуск без ключа' },
+] as const
+
+interface EquipmentOption {
+  value: string
+  label: string
+}
+
+export const EQUIPMENT_CATEGORIES: { category: string; options: EquipmentOption[] }[] = [
+  {
+    category: 'Мультимедиа и связь',
+    options: [
+      { value: 'navigation_system', label: 'Навигация' },
+      { value: 'bluetooth', label: 'Bluetooth' },
+      { value: 'apple_carplay', label: 'Apple CarPlay' },
+      { value: 'android_auto', label: 'Android Auto' },
+      { value: 'touchscreen', label: 'Сенсорный экран' },
+      { value: 'multimedia_system', label: 'Мультимедиа-система' },
+      { value: 'digital_instrument_cluster', label: 'Цифровая приборная панель' },
+      { value: 'head_up_display', label: 'Проекционный дисплей (Head-up)' },
+      { value: 'voice_control', label: 'Голосовое управление' },
+      { value: 'hands_free', label: 'Hands-free' },
+      { value: 'usb', label: 'USB' },
+      { value: 'aux_input', label: 'AUX-разъём' },
+      { value: 'power_outlet_12v', label: 'Розетка 12V' },
+      { value: 'hard_disk', label: 'Жёсткий диск' },
+      { value: 'subwoofer', label: 'Сабвуфер' },
+      { value: 'mp3', label: 'MP3' },
+      { value: 'digital_radio', label: 'Цифровое радио' },
+      { value: 'radio_cassette', label: 'Радио/Магнитола' },
+      { value: 'radio_cd', label: 'Радио CD' },
+      { value: 'cd_changer', label: 'CD-чейнджер' },
+      { value: 'dvd_tv', label: 'DVD/TV' },
+    ],
+  },
+  {
+    category: 'Безопасность и ассистенты',
+    options: [
+      { value: 'cruise_control', label: 'Круиз-контроль' },
+      { value: 'adaptive_cruise_control', label: 'Адаптивный круиз-контроль' },
+      { value: 'automatic_parking', label: 'Автопарковка' },
+      { value: 'parking_sensors', label: 'Парктроник' },
+      { value: 'camera', label: 'Камера' },
+      { value: 'camera_360', label: 'Камера 360°' },
+      { value: 'front_night_vision_camera', label: 'Камера ночного видения' },
+      { value: 'mirror_tilt_in_reverse', label: 'Зеркало наклоняется при заднем ходе' },
+      { value: 'start_stop_system', label: 'Старт-стоп' },
+      { value: 'hill_start_assist', label: 'Помощь при старте на подъёме' },
+      { value: 'tire_pressure_monitor', label: 'Контроль давления в шинах' },
+      { value: 'electronic_parking_brake', label: 'Электронный ручник' },
+      { value: 'ceramic_brakes', label: 'Керамические тормоза' },
+      { value: 'isofix', label: 'ISOFIX' },
+      { value: 'factory_child_seat', label: 'Заводское детское кресло' },
+      { value: 'drive_mode_selector', label: 'Режимы движения' },
+      { value: 'autonomous_driving', label: 'Автономное вождение' },
+    ],
+  },
+  {
+    category: 'Комфорт и удобство',
+    options: [
+      { value: 'power_steering', label: 'Гидроусилитель руля' },
+      { value: 'multifunction_steering_wheel', label: 'Мультифункциональный руль' },
+      { value: 'remote_central_locking', label: 'Дистанционный центральный замок' },
+      { value: 'keyless_start', label: 'Запуск без ключа' },
+      { value: 'trip_computer', label: 'Бортовой компьютер' },
+      { value: 'power_windows', label: 'Электростеклоподъёмники' },
+      { value: 'power_mirrors', label: 'Электрозеркала' },
+      { value: 'heated_mirrors', label: 'Подогрев зеркал' },
+      { value: 'power_folding_mirrors', label: 'Складывающиеся электрозеркала' },
+      { value: 'auto_dimming_mirror', label: 'Автозатемнение зеркала' },
+      { value: 'soft_close_doors', label: 'Доводчики дверей' },
+      { value: 'power_trunk_opening', label: 'Электрооткрывание багажника' },
+      { value: 'power_trunk_closing', label: 'Электрозакрывание багажника' },
+      { value: 'wireless_phone_charging', label: 'Беспроводная зарядка телефона' },
+      { value: 'ambient_lighting', label: 'Атмосферная подсветка' },
+      { value: 'cup_holders', label: 'Подстаканники' },
+      { value: 'cooled_glovebox', label: 'Охлаждаемый бардачок' },
+      { value: 'armrest', label: 'Подлокотник' },
+      { value: 'rain_sensor', label: 'Датчик дождя' },
+      { value: 'light_sensor', label: 'Датчик света' },
+      { value: 'heated_windshield', label: 'Подогрев лобового стекла' },
+      { value: 'auxiliary_heater', label: 'Автономный отопитель (Webasto)' },
+    ],
+  },
+  {
+    category: 'Сиденья и салон',
+    options: [
+      { value: 'height_adjustable_seats', label: 'Регулировка сидений по высоте' },
+      { value: 'power_adjustable_seats', label: 'Электрорегулировка сидений' },
+      { value: 'heated_seats', label: 'Подогрев сидений' },
+      { value: 'ventilated_seats', label: 'Вентиляция сидений' },
+      { value: 'massage_seats', label: 'Массаж сидений' },
+      { value: 'seat_memory', label: 'Память положения сидений' },
+      { value: 'sport_seats', label: 'Спортивные сиденья' },
+      { value: 'rear_window_curtains', label: 'Шторки на задние стёкла' },
+    ],
+  },
+  {
+    category: 'Освещение',
+    options: [
+      { value: 'fog_lights', label: 'Противотуманные фары' },
+      { value: 'xenon_headlights', label: 'Ксеноновые фары' },
+      { value: 'led_headlights', label: 'LED фары (передние)' },
+      { value: 'led_taillights', label: 'LED фонари (задние)' },
+      { value: 'adaptive_headlights', label: 'Адаптивные фары' },
+      { value: 'matrix_headlights', label: 'Матричные фары' },
+      { value: 'daytime_running_lights', label: 'Дневные ходовые огни' },
+      { value: 'headlight_washers', label: 'Омыватели фар' },
+    ],
+  },
+  {
+    category: 'Экстерьер',
+    options: [
+      { value: 'metallic_paint', label: 'Металлик' },
+      { value: 'body_colored_bumpers', label: 'Бамперы в цвет кузова' },
+      { value: 'sunroof', label: 'Люк' },
+      { value: 'panoramic_roof', label: 'Панорамная крыша' },
+      { value: 'tinted_windows', label: 'Тонированные стёкла' },
+      { value: 'roof_rack', label: 'Багажник на крышу' },
+      { value: 'tow_hook', label: 'Фаркоп' },
+      { value: 'alloy_wheels', label: 'Легкосплавные диски' },
+      { value: 'spare_wheel', label: 'Запасное колесо' },
+      { value: 'ski_bag', label: 'Лыжный багажник (шторка)' },
+      { value: 'ski_hatch', label: 'Лючок для лыж' },
+    ],
+  },
+  {
+    category: 'Руль',
+    options: [
+      { value: 'leather_steering_wheel', label: 'Кожаный руль' },
+      { value: 'wood_leather_steering_wheel', label: 'Руль дерево/кожа' },
+      { value: 'steering_wheel_height_adjustment', label: 'Регулировка руля по высоте' },
+      { value: 'heated_steering_wheel', label: 'Подогрев руля' },
+      { value: 'paddle_shifters', label: 'Подрулевые лепестки' },
+    ],
+  },
+  {
+    category: 'Ходовая часть',
+    options: [
+      { value: 'air_suspension', label: 'Пневмоподвеска' },
+      { value: 'sport_suspension', label: 'Спортивная подвеска' },
+      { value: 'four_wheel_steering', label: 'Полноуправляемое шасси (4 колеса)' },
+      { value: 'differential_lock', label: 'Блокировка дифференциала' },
+      { value: 'dpf_filter', label: 'Сажевый фильтр (DPF)' },
+    ],
+  },
+]
+
 export const PAGE_SIZE = 20
 export const DRILL_DOWN_PAGE_SIZE = 10

--- a/migrations/versions/a7b8c9d0e1f2_add_listing_equipment.py
+++ b/migrations/versions/a7b8c9d0e1f2_add_listing_equipment.py
@@ -1,0 +1,35 @@
+"""add listing equipment
+
+Revision ID: a7b8c9d0e1f2
+Revises: f6a7b8c9d0e1
+Create Date: 2026-09-10 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'a7b8c9d0e1f2'
+down_revision: Union[str, Sequence[str], None] = 'f6a7b8c9d0e1'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'listings',
+        sa.Column('equipment', postgresql.ARRAY(sa.String()), nullable=False, server_default='{}'),
+    )
+    op.alter_column('listings', 'equipment', server_default=None)
+    op.create_index(
+        op.f('ix_listings_equipment'), 'listings', ['equipment'], unique=False, postgresql_using='gin'
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f('ix_listings_equipment'), table_name='listings', postgresql_using='gin')
+    op.drop_column('listings', 'equipment')

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -7,7 +7,7 @@ from app.models.listing import Listing, ListingStatus
 from app.scraping.fetch_outcome import FetchBlockedError, FetchOutcome, ParserError
 from app.scraping.pipeline import run_scrape
 from app.search.query import SearchQuery
-from app.sources.base import SourceListing
+from app.sources.base import SourceListing, SourceListingRef
 
 
 def _listing(external_id: str, price: int) -> SourceListing:
@@ -39,6 +39,33 @@ class StubAdapter:
                 self.outcome_sink(FetchOutcome.SUCCESS)
             yield _listing(external_id, 10_000)
 
+    async def fetch_listing(self, ref: SourceListingRef) -> SourceListing:
+        return _listing(ref.external_id, 10_000)
+
+
+class StubAdapterWithEquipment(StubAdapter):
+    """Tracks fetch_listing calls (as a class attribute, since the pipeline instantiates a fresh
+    adapter per run_scrape() call — see app/sources/registry.py) so tests can assert equipment is
+    backfilled only once per listing (on creation), not re-fetched on every re-crawl. Each test
+    gets its own isolated subclass via _make_stub_adapter_with_equipment below.
+    """
+
+    fetch_listing_calls: list[str]
+
+    async def fetch_listing(self, ref: SourceListingRef) -> SourceListing:
+        self.fetch_listing_calls.append(ref.external_id)
+        listing = _listing(ref.external_id, 10_000)
+        listing.equipment = ["bluetooth", "apple_carplay"]
+        return listing
+
+
+def _make_stub_adapter_with_equipment(external_ids: list[str]) -> type[StubAdapterWithEquipment]:
+    return type(
+        "_ConfiguredStubAdapterWithEquipment",
+        (StubAdapterWithEquipment,),
+        {"external_ids": external_ids, "fetch_listing_calls": []},
+    )
+
 
 def _make_stub_adapter(external_ids: list[str]) -> type[StubAdapter]:
     return type("_ConfiguredStubAdapter", (StubAdapter,), {"external_ids": external_ids})
@@ -62,6 +89,9 @@ class StubBlockedAdapter:
             self.outcome_sink(FetchOutcome.FORBIDDEN)
         raise FetchBlockedError(FetchOutcome.FORBIDDEN)
 
+    async def fetch_listing(self, ref: SourceListingRef) -> SourceListing:
+        return _listing(ref.external_id, 10_000)
+
 
 class StubParserErrorAdapter:
     source_code = "stub_source"
@@ -79,6 +109,9 @@ class StubParserErrorAdapter:
         if self.outcome_sink:
             self.outcome_sink(FetchOutcome.PARSER_ERROR)
         raise ParserError("unexpected page shape")
+
+    async def fetch_listing(self, ref: SourceListingRef) -> SourceListing:
+        return _listing(ref.external_id, 10_000)
 
 
 async def test_run_scrape_persists_partial_results_when_blocked_mid_crawl(session, monkeypatch):
@@ -145,3 +178,19 @@ async def test_run_scrape_skips_mark_removed_when_blocked_mid_crawl(session, mon
     assert stats.listings_removed == 0
     statuses = {listing.status for listing in (await session.execute(select(Listing))).scalars().all()}
     assert statuses == {ListingStatus.ACTIVE}
+
+
+async def test_run_scrape_backfills_equipment_once_on_creation(session, monkeypatch):
+    """Search-page results don't carry equipment (see mapper.py), so a new listing gets one
+    detail-page fetch to backfill it — but only once, not on every re-crawl of the same listing.
+    """
+    adapter_cls = _make_stub_adapter_with_equipment(["1"])
+    monkeypatch.setitem(registry.SOURCE_REGISTRY, "stub_source", adapter_cls)
+
+    await run_scrape(session, source_code="stub_source", query=SearchQuery())
+    listing = (await session.execute(select(Listing))).scalar_one()
+    assert listing.equipment == ["bluetooth", "apple_carplay"]
+    assert adapter_cls.fetch_listing_calls == ["1"]
+
+    await run_scrape(session, source_code="stub_source", query=SearchQuery())
+    assert adapter_cls.fetch_listing_calls == ["1"]  # not called again for the already-known listing

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -170,6 +170,9 @@ class StubPageSkippedAdapter:
             self.outcome_sink(FetchOutcome.SUCCESS)
         yield _listing("2", 12_000)
 
+    async def fetch_listing(self, ref: SourceListingRef) -> SourceListing:
+        return _listing(ref.external_id, 10_000)
+
 
 async def test_run_scrape_marks_blocked_when_a_page_was_skipped(session, monkeypatch):
     monkeypatch.setitem(registry.SOURCE_REGISTRY, "stub_source", StubPageSkippedAdapter)

--- a/tests/unit/test_polovni_adapter.py
+++ b/tests/unit/test_polovni_adapter.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 
 import pytest
@@ -75,6 +76,21 @@ def test_parse_listing_extracts_full_detail():
     assert "safety" in listing.raw
     assert "equipment" in listing.raw
     assert listing.image_url == "https://cdn.polovniautomobili.com/user-images/thumbs/3013/30136732/0d3bcb74b14a.jpg"
+    # equipment is translated to normalized slugs for filtering (see mapper._EQUIPMENT_NORMALIZED)
+    assert "bluetooth" in listing.equipment
+    assert "apple_carplay" in listing.equipment
+    assert "adaptive_cruise_control" in listing.equipment
+    assert all(re.fullmatch(r"[a-z0-9_]+", item) for item in listing.equipment)  # nothing left untranslated
+
+
+def test_parse_search_page_does_not_include_equipment():
+    html = (FIXTURES / "search_page_01.html").read_text(encoding="utf-8")
+    adapter = PolovniAutomobiliSource()
+
+    listings, _ = adapter.parse_search_page(html)
+
+    # The search/results page JSON simply doesn't carry `equipment` — see mapper.py's docstring.
+    assert all(listing.equipment == [] for listing in listings)
 
 
 def test_fetcher_is_configured_from_settings():


### PR DESCRIPTION
## Summary
- Equipment (Oprema) was never scraped: search-page results don't carry it, and the detail-page fetch path was unused. Now a new listing gets one detail-page fetch to backfill it (only once, on creation).
- Serbian equipment values are normalized to stable English slugs (`app/sources/polovniautomobili/mapper.py`) and stored on `Listing.equipment` (Postgres `ARRAY` + GIN index), queryable via `SearchQuery.equipment` (array containment — must have ALL listed features).
- Frontend: instead of 97 checkboxes, the filter shows 10 hand-picked popular features as chips plus an expandable, searchable panel with the rest grouped into 8 categories. That hand-picked list is a known gap — tracked in #93 to replace it with actual usage data once there's enough of it.

## Test plan
- [x] `pytest tests/` — 206 passed
- [x] `tsc -b` / `oxlint` clean on frontend
- [x] Manually verified the equipment filter UI (chip toggle, expand panel, search-within-panel) in the browser preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)