### PR TITLE
Commit scrape results periodically instead of once at end of crawl

### DIFF
--- a/app/scraping/pipeline.py
+++ b/app/scraping/pipeline.py
@@ -19,6 +19,13 @@ from app.search.query import SearchQuery
 from app.sources.base import CarSource, SourceListing, SourceListingRef
 from app.sources.registry import get_source_adapter
 
+# Commit every N upserted listings instead of once at the end of the whole crawl. A full crawl can
+# span many minutes of network I/O (page fetches, per-listing detail fetches); holding one
+# transaction open across all of it holds row locks on every updated Listing for the run's entire
+# duration and loses all already-scraped work if something later in the run raises an exception
+# the caller doesn't treat as a partial-success case (see app/scraping/worker.py's except clause).
+_COMMIT_BATCH_SIZE = 50
+
 
 @dataclass
 class ScrapeStats:
@@ -129,6 +136,9 @@ async def run_scrape(
                 stats.listings_updated += 1
                 if previous_price is not None and previous_price > listing.price:
                     stats.price_drops.append((listing.id, previous_price, listing.price))
+
+            if stats.listings_seen % _COMMIT_BATCH_SIZE == 0:
+                await session.commit()
     except (FetchBlockedError, ParserError) as exc:
         # Stop pagination early but keep whatever was already upserted this run — a partial
         # result is more useful than losing it. FetchBlockedError means the source just told us

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -6,7 +6,7 @@ import app.sources.registry as registry
 from app.models.listing import Listing, ListingStatus
 from app.models.scrape_rate_limit import ScrapeRateLimit
 from app.scraping.fetch_outcome import FetchBlockedError, FetchOutcome, ParserError
-from app.scraping.pipeline import run_scrape
+from app.scraping.pipeline import _COMMIT_BATCH_SIZE, run_scrape
 from app.search.query import SearchQuery
 from app.sources.base import SourceListing, SourceListingRef
 
@@ -273,3 +273,32 @@ async def test_run_scrape_passes_admin_configured_rate_limit_to_adapter(session,
     assert received_kwargs["delay"] == 0.11
     assert received_kwargs["jitter"] == 0.05
     assert received_kwargs["network_error_retry_delay"] == 1.5
+
+
+async def test_run_scrape_commits_periodically_during_a_long_crawl(session, monkeypatch):
+    """A long crawl shouldn't hold everything in one uncommitted transaction until the very end —
+    see the module docstring on _COMMIT_BATCH_SIZE for why (long-held row locks, and losing an
+    entire run's work to an exception the caller doesn't treat as partial-success).
+    """
+    external_ids = [str(i) for i in range(_COMMIT_BATCH_SIZE * 2 + 3)]
+    monkeypatch.setitem(registry.SOURCE_REGISTRY, "stub_source", _make_stub_adapter(external_ids))
+
+    commit_count = 0
+    original_commit = session.commit
+
+    async def _counting_commit():
+        nonlocal commit_count
+        commit_count += 1
+        await original_commit()
+
+    monkeypatch.setattr(session, "commit", _counting_commit)
+
+    stats = await run_scrape(session, source_code="stub_source", query=SearchQuery())
+
+    assert stats.listings_created == len(external_ids)
+    # Two mid-crawl commits (at _COMMIT_BATCH_SIZE and 2 * _COMMIT_BATCH_SIZE listings seen) plus
+    # the final commit at the end of run_scrape.
+    assert commit_count == 3
+
+    persisted = (await session.execute(select(Listing))).scalars().all()
+    assert len(persisted) == len(external_ids)


### PR DESCRIPTION
## Summary
- `run_scrape` held a single Postgres transaction open across an entire crawl — potentially minutes of network I/O across many pages and per-listing detail fetches — holding row locks on every updated `Listing` for the run's whole duration.
- If anything raised after listings were upserted but wasn't already treated as a partial-success case (`FetchBlockedError`/`ParserError`), the whole run's already-scraped work was lost on rollback (see the `except` clause in `app/scraping/worker.py`).
- `run_scrape` now commits every `_COMMIT_BATCH_SIZE` (50) listings instead of only at the end. The existing final commit is unchanged and still picks up the last partial batch plus `mark_missing_as_removed`.

## Test plan
- [x] `pytest tests/unit/test_pipeline.py` — added `test_run_scrape_commits_periodically_during_a_long_crawl`, asserting `session.commit()` fires at the expected batch boundaries for a >100-listing crawl and all listings still persist
- [x] `pytest tests/unit` (full suite, 207 passed)
- [x] `ruff check` / `mypy` on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)