### PR TITLE
Size scrape job timeout to max_pages, fix jobs stuck at RUNNING forever

### DIFF
--- a/app/scraping/worker.py
+++ b/app/scraping/worker.py
@@ -5,11 +5,12 @@ arq idiom — rather than fetched inside run_scrape_job, so the task function ca
 in tests with a hand-built ctx dict, no monkeypatching required.
 """
 
+import asyncio
 import uuid
 from datetime import datetime, timezone
 from typing import Any
 
-from arq import cron
+from arq import cron, func
 from arq.connections import RedisSettings
 
 from app.auth.email import get_email_sender
@@ -21,8 +22,35 @@ from app.notifications.delivery import send_notification_email
 from app.notifications.matching import generate_notifications_for_job
 from app.scraping.pipeline import run_scrape
 from app.scraping.proxy import get_proxy_provider
+from app.scraping.rate_limit import get_scrape_rate_limit
 from app.scraping.scheduler import run_due_saved_search_scrapes, run_due_scheduled_scrapes
 from app.scraping.schemas import decode_job_query
+
+# arq's own ceiling on the whole run_scrape_job call (it wraps every job in its own
+# asyncio.wait_for, default 300s). Set deliberately far above anything _estimate_job_timeout_seconds
+# below should ever produce for a realistic max_pages — this is only a last-resort net for a truly
+# wedged run, not the real per-job limit.
+_ARQ_HARD_TIMEOUT_SECONDS = 24 * 60 * 60
+
+# A scrape job's own soft timeout, sized to its max_pages instead of one flat number for every
+# job — a 5-page SEARCH and a 500-page FULL_SOURCE_REFRESH need wildly different budgets, and
+# arq's flat 300s default killed both indiscriminately after exactly 5 minutes regardless (see the
+# incident this fixes: two jobs — one 500-page FULL_SOURCE_REFRESH, one 50-page SEARCH for "Alfa
+# Romeo" — both silently cancelled mid-crawl and left stuck at RUNNING forever).
+#
+# Worst case per page is 1 search-page fetch + one equipment-detail fetch per listing on that page
+# (every listing turns out to be brand new — see pipeline.py's _enrich_with_equipment). 25 matches
+# the resultsPerPage Polovni Automobili actually returns (tests/fixtures/polovniautomobili/
+# search_page_01.html) — not load-bearing on real scraping behavior, just the assumption this
+# estimate is built on. Each of those requests is paced up to delay+jitter apart. The floor keeps
+# small jobs at least as much headroom as the old flat default had.
+_ASSUMED_LISTINGS_PER_PAGE = 25
+_MIN_JOB_TIMEOUT_SECONDS = 300.0
+
+
+def _estimate_job_timeout_seconds(max_pages: int, delay: float, jitter: float) -> float:
+    requests_per_page = 1 + _ASSUMED_LISTINGS_PER_PAGE
+    return max(_MIN_JOB_TIMEOUT_SECONDS, max_pages * requests_per_page * (delay + jitter))
 
 
 async def _on_startup(ctx: dict[str, Any]) -> None:
@@ -47,25 +75,48 @@ async def run_scrape_job(ctx: dict[str, Any], job_id: str) -> None:
         source = await session.get(Source, job.source_id)
         assert source is not None
         query, max_pages = decode_job_query(job.query)
+        rate_limit = await get_scrape_rate_limit(session)
+        timeout_seconds = _estimate_job_timeout_seconds(
+            max_pages, rate_limit.request_delay_seconds, rate_limit.request_jitter_seconds
+        )
 
         try:
-            stats = await run_scrape(
-                session,
-                source_code=source.code,
-                query=query,
-                max_pages=max_pages,
-                proxy_provider=ctx["proxy_provider"],
-                mark_removed=job.job_type == ScrapeJobType.FULL_SOURCE_REFRESH,
+            stats = await asyncio.wait_for(
+                run_scrape(
+                    session,
+                    source_code=source.code,
+                    query=query,
+                    max_pages=max_pages,
+                    proxy_provider=ctx["proxy_provider"],
+                    mark_removed=job.job_type == ScrapeJobType.FULL_SOURCE_REFRESH,
+                ),
+                timeout=timeout_seconds,
             )
-        except Exception as exc:  # noqa: BLE001 - persisted below, not swallowed silently
+        except (Exception, asyncio.CancelledError) as exc:  # noqa: BLE001 - persisted below, not swallowed silently
             # A failure inside run_scrape (e.g. an IntegrityError from a concurrent scrape of the
             # same source racing on the same new listing) leaves the session's transaction needing
             # an explicit rollback before it can be used again — without this, the commit() below
             # itself raises PendingRollbackError, so the real failure never gets recorded and the
             # job is left stuck instead of FAILED.
+            #
+            # asyncio.CancelledError is caught explicitly alongside Exception — it isn't a subclass
+            # of Exception (BaseException instead, since Python 3.8) — so a cancellation, whether
+            # from the timeout above or an external one (arq's own hard ceiling, a worker
+            # shutdown), still gets persisted as FAILED with error detail instead of leaving the
+            # row stuck at RUNNING forever with no trace, which is exactly what silently happened
+            # before this: `except Exception` let CancelledError straight through uncaught.
             await session.rollback()
             job.status = ScrapeJobStatus.FAILED
-            job.error = {"type": type(exc).__name__, "message": str(exc)}
+            if isinstance(exc, (TimeoutError, asyncio.CancelledError)):
+                job.error = {
+                    "type": type(exc).__name__,
+                    "message": (
+                        f"Scrape job exceeded its computed timeout of {timeout_seconds:.0f}s "
+                        f"(max_pages={max_pages}), or was cancelled"
+                    ),
+                }
+            else:
+                job.error = {"type": type(exc).__name__, "message": str(exc)}
             job.finished_at = datetime.now(timezone.utc)
             await session.commit()
             raise
@@ -89,7 +140,7 @@ async def run_scrape_job(ctx: dict[str, Any], job_id: str) -> None:
 
 
 class WorkerSettings:
-    functions = [run_scrape_job, send_notification_email]
+    functions = [func(run_scrape_job, timeout=_ARQ_HARD_TIMEOUT_SECONDS), send_notification_email]
     cron_jobs = [cron(run_due_scheduled_scrapes, second=0), cron(run_due_saved_search_scrapes, second=0)]
     on_startup = _on_startup
     redis_settings = RedisSettings.from_dsn(get_settings().redis_url)

--- a/tests/unit/test_worker.py
+++ b/tests/unit/test_worker.py
@@ -1,3 +1,4 @@
+import asyncio
 import uuid
 from datetime import datetime, timezone
 
@@ -234,6 +235,44 @@ async def test_run_scrape_job_requests_mark_removed_only_for_full_source_refresh
         full_refresh_job = await session.get(ScrapeJob, full_refresh_job_id)
         assert search_job.stats["listings_removed"] == 0
         assert full_refresh_job.stats["listings_removed"] == 2
+
+
+def test_estimate_job_timeout_seconds_scales_with_max_pages():
+    # Floor: a tiny job doesn't get squeezed below the old flat default.
+    assert worker_module._estimate_job_timeout_seconds(max_pages=1, delay=0.8, jitter=0.4) == (
+        worker_module._MIN_JOB_TIMEOUT_SECONDS
+    )
+    # A big job's budget scales with max_pages instead of being capped at the same 300s.
+    big = worker_module._estimate_job_timeout_seconds(max_pages=500, delay=0.8, jitter=0.4)
+    assert big == pytest.approx(500 * (1 + worker_module._ASSUMED_LISTINGS_PER_PAGE) * 1.2)
+    assert big > worker_module._MIN_JOB_TIMEOUT_SECONDS
+
+
+async def test_run_scrape_job_marks_failed_on_computed_timeout(worker_session_factory, monkeypatch):
+    """A job that outruns its computed timeout gets cancelled and recorded as FAILED instead of
+    being left stuck at RUNNING forever. Reproduces the bug this fixes: arq's own flat 300s
+    job_timeout used to cancel jobs like this via asyncio.CancelledError, which the old `except
+    Exception` handler didn't catch (CancelledError is a BaseException, not an Exception, since
+    Python 3.8) — so the job row never got updated and stayed RUNNING with no trace of the failure.
+    """
+    job_id = await _seed_job(worker_session_factory)
+    monkeypatch.setattr(worker_module, "_estimate_job_timeout_seconds", lambda *args, **kwargs: 0.05)
+
+    async def fake_run_scrape(session, source_code, query, max_pages=5, proxy_provider=None, mark_removed=False):
+        await asyncio.sleep(10)
+        return ScrapeStats()
+
+    monkeypatch.setattr(worker_module, "run_scrape", fake_run_scrape)
+
+    ctx = {"session_factory": worker_session_factory, "proxy_provider": NullProxyProvider()}
+    with pytest.raises(TimeoutError):
+        await worker_module.run_scrape_job(ctx, str(job_id))
+
+    async with worker_session_factory() as session:
+        job = await session.get(ScrapeJob, job_id)
+        assert job.status == ScrapeJobStatus.FAILED
+        assert job.error["type"] == "TimeoutError"
+        assert job.finished_at is not None
 
 
 async def test_run_scrape_job_skips_already_cancelled_job(worker_session_factory, monkeypatch):


### PR DESCRIPTION
## Summary
- arq's flat 300s `job_timeout` was silently cancelling any scrape crawl that ran longer than 5 minutes (any real `SEARCH`/`FULL_SOURCE_REFRESH` job), and the resulting `asyncio.CancelledError` slipped past `run_scrape_job`'s `except Exception` handler uncaught (`CancelledError` is a `BaseException`, not an `Exception`, since Python 3.8) — so the job row's status was never flipped to `FAILED` and stayed `RUNNING` forever with no error recorded.
- Reproduced in production via Railway worker logs: a 500-page `FULL_SOURCE_REFRESH` and a 50-page `SEARCH` for "Alfa Romeo" were both cancelled exactly 300.00s after starting and had been stuck at `RUNNING` for hours.
- `run_scrape_job` now computes its own timeout from the job's `max_pages` (worst case: one search-page fetch plus one equipment-detail fetch per listing, all paced at the admin-configured delay+jitter) and wraps `run_scrape` in its own `asyncio.wait_for` with that budget, instead of relying on arq's one-size-fits-all default. arq's own per-function timeout is raised to a 24h last-resort ceiling.
- The except clause now also catches `asyncio.CancelledError` alongside `Exception`, so any cancellation — this computed timeout or an external one — gets persisted as `FAILED` with error detail instead of leaving the row stuck.

## Test plan
- [x] `pytest tests/unit/test_worker.py -v` — 10 passed, including new tests for the timeout formula and for a job that outruns its computed timeout ending up `FAILED` with a recorded error
- [x] `pytest -q` — full suite, 214 passed
- [x] `ruff check` / `mypy` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)