### PR TITLE
Anchor search pagination to page 1, retry parser errors via proxy

### DIFF
--- a/app/scraping/fetch_strategy.py
+++ b/app/scraping/fetch_strategy.py
@@ -21,7 +21,7 @@ from app.scraping.fetch_outcome import (
     classify_exception,
     classify_response,
 )
-from app.scraping.proxy import FetchError, FetchMetrics, ProxyProvider
+from app.scraping.proxy import FetchError, FetchMetrics, ProxyEndpoint, ProxyProvider
 from scraping.utilities import default_request_headers
 
 
@@ -36,7 +36,7 @@ class FetchResult:
 
 
 class FetchStrategy(Protocol):
-    async def fetch(self, url: str) -> FetchResult: ...
+    async def fetch(self, url: str, *, force_proxy: bool = False) -> FetchResult: ...
 
 
 def _http_request(
@@ -96,7 +96,9 @@ class HttpFetcher:
         self._outcome_sink = outcome_sink
         self._pacer = _RequestPacer(delay, jitter)
 
-    async def fetch(self, url: str) -> FetchResult:
+    async def fetch(self, url: str, *, force_proxy: bool = False) -> FetchResult:
+        # force_proxy is accepted only to satisfy FetchStrategy — this fetcher has no proxy to
+        # force, by design (see class docstring), so it's a no-op here.
         await self._pacer.wait()
         outcome, response, detail = await asyncio.to_thread(_http_request, self.session, url, self.timeout, None)
         if self._outcome_sink is not None:
@@ -148,8 +150,32 @@ class ProxyHttpFetcher:
     async def _direct(self, url: str) -> tuple[FetchOutcome, requests.Response | None, str | None]:
         return await asyncio.to_thread(_http_request, self.session, url, self.timeout, None)
 
-    async def fetch(self, url: str) -> FetchResult:
+    async def _via_proxy(self, url: str, proxy: ProxyEndpoint) -> FetchResult:
+        proxy_outcome, proxy_response, proxy_detail = await asyncio.to_thread(
+            _http_request, self.session, url, self.timeout, proxy.url
+        )
+        self._record(proxy_outcome)
+        if proxy_outcome == FetchOutcome.SUCCESS:
+            assert proxy_response is not None
+            await self.proxy_provider.report_success(proxy, FetchMetrics(status_code=proxy_response.status_code))
+        else:
+            await self.proxy_provider.report_failure(proxy, FetchError(outcome=proxy_outcome))
+        return _to_result(proxy_outcome, proxy_response, proxy_detail)
+
+    async def fetch(self, url: str, *, force_proxy: bool = False) -> FetchResult:
+        """`force_proxy` skips the direct attempt entirely and goes straight to proxy — for a
+        caller that already knows a same-IP retry can't tell it anything new (e.g. a search page
+        that fetched fine, HTTP-wise, but failed to parse; see
+        PolovniAutomobiliSource._iter_search_pages). Falls back to the normal direct-first flow if
+        no proxy happens to be available, rather than giving up.
+        """
         await self._pacer.wait()
+
+        if force_proxy:
+            proxy = await self.proxy_provider.acquire(self.source)
+            if proxy is not None:
+                return await self._via_proxy(url, proxy)
+
         outcome, response, detail = await self._direct(url)
         self._record(outcome)
 
@@ -165,16 +191,7 @@ class ProxyHttpFetcher:
         if proxy is None:
             return _to_result(outcome, response, detail)
 
-        proxy_outcome, proxy_response, proxy_detail = await asyncio.to_thread(
-            _http_request, self.session, url, self.timeout, proxy.url
-        )
-        self._record(proxy_outcome)
-        if proxy_outcome == FetchOutcome.SUCCESS:
-            assert proxy_response is not None
-            await self.proxy_provider.report_success(proxy, FetchMetrics(status_code=proxy_response.status_code))
-        else:
-            await self.proxy_provider.report_failure(proxy, FetchError(outcome=proxy_outcome))
-        return _to_result(proxy_outcome, proxy_response, proxy_detail)
+        return await self._via_proxy(url, proxy)
 
 
 class PlaywrightFetcher:
@@ -187,7 +204,7 @@ class PlaywrightFetcher:
     def __init__(self, timeout: int = 15):
         self.timeout = timeout
 
-    async def fetch(self, url: str) -> FetchResult:
+    async def fetch(self, url: str, *, force_proxy: bool = False) -> FetchResult:
         raise NotImplementedError(
             "PlaywrightFetcher is a stub — browser-based fetching isn't implemented yet "
             "(docs/adr/05_ANTI_BOT_PROXY.md §6)."

--- a/app/sources/polovniautomobili/adapter.py
+++ b/app/sources/polovniautomobili/adapter.py
@@ -136,18 +136,20 @@ class PolovniAutomobiliSource:
             self._record(FetchOutcome.PARSER_ERROR)
             raise ParserError(str(exc)) from exc
 
-    async def _fetch(self, url: str) -> str:
-        result = await self.fetcher.fetch(url)
+    async def _fetch(self, url: str, *, force_proxy: bool = False) -> str:
+        result = await self.fetcher.fetch(url, force_proxy=force_proxy)
         return raise_for_blocked(result, url)
 
-    async def _fetch_search_page(self, url: str, page: int) -> tuple[list[SourceListing], int] | None:
+    async def _fetch_search_page(
+        self, url: str, page: int, *, force_proxy: bool = False
+    ) -> tuple[list[SourceListing], int] | None:
         """One fetch+parse attempt for a search page. Returns None (rather than raising) on a
         parse failure, so `_iter_search_pages` can retry or skip the page instead of aborting the
         whole crawl — a fetch failure (FetchBlockedError, or the RuntimeError raise_for_blocked
         raises for TIMEOUT/SERVER_ERROR) still propagates normally, since those aren't
         page-specific and retrying won't help.
         """
-        html = await self._fetch(url)
+        html = await self._fetch(url, force_proxy=force_proxy)
         try:
             return self._guard_parse(self.parse_search_page, html)
         except ParserError as exc:
@@ -171,10 +173,14 @@ class PolovniAutomobiliSource:
             url = self.build_search_url(query, page)
             result = await self._fetch_search_page(url, page)
             if result is None:
-                # One retry: a parse failure could be a transient odd response. A second
-                # consecutive failure means this page really can't be parsed — skip it and keep
-                # crawling the rest of the source rather than losing everything after it.
-                result = await self._fetch_search_page(url, page)
+                # One retry, forced through the proxy: the first attempt already got HTTP 200 (a
+                # ParserError only happens after a successful fetch, see
+                # app/scraping/fetch_outcome.py) — a same-IP direct retry would just ask the exact
+                # same origin the exact same question again. A different egress IP is the one
+                # thing a retry can actually change, and is exactly what fetch_outcome.py's
+                # BLOCK_LIKE-only proxy escalation misses for this case: the response looked like
+                # a plain success (200, parseable-looking body), just not one we could use.
+                result = await self._fetch_search_page(url, page, force_proxy=True)
             if result is None:
                 logger.warning("polovniautomobili: page %d skipped after two failed parse attempts (%s)", page, url)
                 self._record(FetchOutcome.PAGE_SKIPPED)

--- a/app/sources/polovniautomobili/adapter.py
+++ b/app/sources/polovniautomobili/adapter.py
@@ -4,6 +4,7 @@ instead of the original PoC's (now-stale) CSS selectors.
 """
 
 import json
+import logging
 import re
 from collections.abc import AsyncIterator, Callable
 from typing import TypeVar
@@ -19,6 +20,8 @@ from app.sources.polovniautomobili.mapper import BASE_URL, map_product_data, map
 from scraping.translation import fuel_type_codes
 
 _T = TypeVar("_T")
+
+logger = logging.getLogger(__name__)
 
 _NEXT_DATA_RE = re.compile(r'<script id="__NEXT_DATA__"[^>]*>(.*?)</script>', re.S)
 _FUEL_CODE_BY_NORMALIZED = {normalize_fuel_type(raw): code for code, raw in fuel_type_codes.items()}
@@ -137,7 +140,7 @@ class PolovniAutomobiliSource:
         result = await self.fetcher.fetch(url)
         return raise_for_blocked(result, url)
 
-    async def _fetch_search_page(self, url: str) -> tuple[list[SourceListing], int] | None:
+    async def _fetch_search_page(self, url: str, page: int) -> tuple[list[SourceListing], int] | None:
         """One fetch+parse attempt for a search page. Returns None (rather than raising) on a
         parse failure, so `_iter_search_pages` can retry or skip the page instead of aborting the
         whole crawl — a fetch failure (FetchBlockedError, or the RuntimeError raise_for_blocked
@@ -147,27 +150,51 @@ class PolovniAutomobiliSource:
         html = await self._fetch(url)
         try:
             return self._guard_parse(self.parse_search_page, html)
-        except ParserError:
+        except ParserError as exc:
+            logger.warning("polovniautomobili: page %d failed to parse (%s): %s", page, url, exc)
             return None
 
     async def _iter_search_pages(self, query: SearchQuery) -> AsyncIterator[SourceListing]:
+        # `page_count` is anchored to whatever page 1 reports and held fixed for the rest of the
+        # crawl, instead of re-trusting it fresh off every page's own response. The site is
+        # supposed to report the same total on every page of one search, but a 2026-09-11
+        # FULL_SOURCE_REFRESH ended at page ~179 instead of the ~2992 the site actually had:
+        # every fetch still classified FetchOutcome.SUCCESS (no 403/429/captcha — see
+        # app/scraping/fetch_outcome.py, so proxy fallback never triggered either), just with a
+        # shrunk pageCount on a later page, and `if page >= page_count: break` took that at face
+        # value and ended the run early. Page 1 is the one page a human can cross-check (the "od
+        # X do Y oglasa od ukupno Z" counter rendered on the page itself), so it's the one value
+        # trusted as the loop bound; a later page disagreeing is logged instead of obeyed.
         page = 1
+        total_page_count: int | None = None
         while page <= self.max_pages:
             url = self.build_search_url(query, page)
-            result = await self._fetch_search_page(url)
+            result = await self._fetch_search_page(url, page)
             if result is None:
                 # One retry: a parse failure could be a transient odd response. A second
                 # consecutive failure means this page really can't be parsed — skip it and keep
                 # crawling the rest of the source rather than losing everything after it.
-                result = await self._fetch_search_page(url)
+                result = await self._fetch_search_page(url, page)
             if result is None:
+                logger.warning("polovniautomobili: page %d skipped after two failed parse attempts (%s)", page, url)
                 self._record(FetchOutcome.PAGE_SKIPPED)
                 page += 1
                 continue
             listings, page_count = result
+            if total_page_count is None:
+                total_page_count = page_count
+            elif page_count != total_page_count:
+                logger.warning(
+                    "polovniautomobili: page %d reports pageCount=%d, page 1 reported %d (%s) — "
+                    "using page 1's count",
+                    page,
+                    page_count,
+                    total_page_count,
+                    url,
+                )
             for listing in listings:
                 yield listing
-            if page >= page_count:
+            if page >= total_page_count:
                 break
             page += 1
 

--- a/tests/unit/test_fetch_strategy.py
+++ b/tests/unit/test_fetch_strategy.py
@@ -99,6 +99,37 @@ async def test_proxy_http_fetcher_falls_back_to_proxy_when_blocked(monkeypatch):
     assert proxy_provider.failures == []
 
 
+async def test_proxy_http_fetcher_force_proxy_skips_direct_attempt(monkeypatch):
+    proxy_provider = FakeProxyProvider()
+    fetcher = ProxyHttpFetcher(source="polovniautomobili", proxy_provider=proxy_provider)
+    seen_proxies = []
+
+    def fake_get(url, timeout, headers, proxies=None):
+        seen_proxies.append(proxies)
+        return _response(200, "via proxy" if proxies else "direct")
+
+    monkeypatch.setattr(fetcher.session, "get", fake_get)
+
+    result = await fetcher.fetch("https://example.com", force_proxy=True)
+
+    assert result.outcome == FetchOutcome.SUCCESS
+    assert result.text == "via proxy"
+    # Exactly one request was made, and it went through the proxy — no direct attempt at all.
+    assert seen_proxies == [{"http": _PROXY.url, "https": _PROXY.url}]
+    assert len(proxy_provider.successes) == 1
+
+
+async def test_proxy_http_fetcher_force_proxy_falls_back_to_direct_when_no_proxy_available(monkeypatch):
+    proxy_provider = FakeProxyProvider(proxy=None)
+    fetcher = ProxyHttpFetcher(source="polovniautomobili", proxy_provider=proxy_provider)
+    monkeypatch.setattr(fetcher.session, "get", lambda *a, **kw: _response(200, "direct ok"))
+
+    result = await fetcher.fetch("https://example.com", force_proxy=True)
+
+    assert result.outcome == FetchOutcome.SUCCESS
+    assert result.text == "direct ok"
+
+
 async def test_proxy_http_fetcher_reports_failure_when_both_blocked(monkeypatch):
     proxy_provider = FakeProxyProvider()
     fetcher = ProxyHttpFetcher(source="polovniautomobili", proxy_provider=proxy_provider)

--- a/tests/unit/test_polovni_adapter.py
+++ b/tests/unit/test_polovni_adapter.py
@@ -257,6 +257,39 @@ async def test_iter_search_pages_recovers_if_retry_parses_successfully(monkeypat
     assert outcomes == [FetchOutcome.PARSER_ERROR]
 
 
+async def test_iter_search_pages_anchors_page_count_to_first_page(monkeypatch, caplog):
+    """A later page under-reporting pageCount (see the 2026-09-11 incident: a FULL_SOURCE_REFRESH
+    ended at page ~179 instead of the site's actual ~2992, entirely through this loop's own exit
+    condition trusting a shrunk pageCount from a later page) must not cut the crawl short — page
+    1's count is the one held fixed, and a later disagreement is only logged.
+    """
+    from app.search.query import SearchQuery
+
+    adapter = PolovniAutomobiliSource(proxy_provider=FakeProxyProvider(), max_pages=5)
+    listing = SourceListing(
+        external_id="1", canonical_url="https://x/1", title="x", make="Skoda", model="Octavia",
+        production_year=2019, mileage_km=1, price=1, currency="EUR",
+    )
+
+    async def fake_fetch(url: str) -> str:
+        return url
+
+    def fake_parse(html: str) -> tuple[list, int]:
+        # page 1 reports 4 total pages; every later page under-reports 1 (as if the site quietly
+        # shrank its own count mid-crawl).
+        return [listing], 4 if "page=1&" in html else 1
+
+    monkeypatch.setattr(adapter, "_fetch", fake_fetch)
+    monkeypatch.setattr(adapter, "parse_search_page", fake_parse)
+
+    with caplog.at_level("WARNING"):
+        results = [item async for item in adapter.search_with_data(SearchQuery())]
+
+    # All 4 pages page 1 promised were crawled, not just 1 — page 1's count won.
+    assert results == [listing] * 4
+    assert "reports pageCount=1, page 1 reported 4" in caplog.text
+
+
 async def test_fetch_listing_records_and_raises_parser_error_on_malformed_page(monkeypatch):
     outcomes: list[FetchOutcome] = []
     adapter = PolovniAutomobiliSource(proxy_provider=FakeProxyProvider(), outcome_sink=outcomes.append)

--- a/tests/unit/test_polovni_adapter.py
+++ b/tests/unit/test_polovni_adapter.py
@@ -198,8 +198,10 @@ async def test_iter_search_pages_retries_once_then_skips_unparseable_page(monkey
     adapter = PolovniAutomobiliSource(proxy_provider=FakeProxyProvider(), outcome_sink=outcomes.append, max_pages=3)
 
     parsed_urls: list[str] = []
+    force_proxy_flags: list[bool] = []
 
-    async def fake_fetch(url: str) -> str:
+    async def fake_fetch(url: str, *, force_proxy: bool = False) -> str:
+        force_proxy_flags.append(force_proxy)
         return url
 
     def fake_parse(html: str) -> tuple[list, int]:
@@ -223,6 +225,8 @@ async def test_iter_search_pages_retries_once_then_skips_unparseable_page(monkey
         FetchOutcome.PARSER_ERROR,
         FetchOutcome.PAGE_SKIPPED,
     ]
+    # The retry (page 1's second attempt) went through the proxy; nothing else did.
+    assert force_proxy_flags == [False, True, False]
 
 
 async def test_iter_search_pages_recovers_if_retry_parses_successfully(monkeypatch):
@@ -237,7 +241,7 @@ async def test_iter_search_pages_recovers_if_retry_parses_successfully(monkeypat
         production_year=2019, mileage_km=1, price=1, currency="EUR",
     )
 
-    async def fake_fetch(url: str) -> str:
+    async def fake_fetch(url: str, *, force_proxy: bool = False) -> str:
         return url
 
     def fake_parse(html: str) -> tuple[list, int]:
@@ -271,7 +275,7 @@ async def test_iter_search_pages_anchors_page_count_to_first_page(monkeypatch, c
         production_year=2019, mileage_km=1, price=1, currency="EUR",
     )
 
-    async def fake_fetch(url: str) -> str:
+    async def fake_fetch(url: str, *, force_proxy: bool = False) -> str:
         return url
 
     def fake_parse(html: str) -> tuple[list, int]:


### PR DESCRIPTION
## Summary
- `_iter_search_pages` re-read `page_count` fresh off every page's own response and trusted it at face value. A 2026-09-11 `FULL_SOURCE_REFRESH` ended at page ~179 instead of the site's actual ~2992 (confirmed live: `totalItems=74795`, `pageCount=2992`) purely through this loop's own `page >= page_count: break` — some page along the way reported a much smaller `pageCount` than page 1 did, with every fetch still classified `FetchOutcome.SUCCESS` (no 403/429/captcha), so proxy fallback never triggered either. `page_count` is now anchored to whatever page 1 reports and held fixed for the rest of the crawl; a later page disagreeing is logged as a warning instead of silently ending the crawl early.
- Adds warning-level logging for parser failures, skipped pages, and pageCount mismatches (page number + URL) — previously invisible beyond a bare count in `job.stats.outcome_counts`, which is what made the above incident hard to diagnose in the first place.
- A search page's `ParserError` retry now goes through the proxy instead of repeating the exact same direct request: a `ParserError` only happens after the fetch already got HTTP 200, so `ProxyHttpFetcher`'s own block-like-triggered proxy fallback never kicks in for it. Added `force_proxy` to `FetchStrategy`/`ProxyHttpFetcher.fetch` (skips the direct attempt, falls back to direct if no proxy is available) and wired the search-page retry to use it.

## Test plan
- [x] `pytest -q` — full suite, 217 passed
- [x] `ruff check` / `mypy` — clean
- [x] New tests: page-1-anchoring survives a later page under-reporting `pageCount` (`test_iter_search_pages_anchors_page_count_to_first_page`); the parser-error retry is forced through the proxy (`test_iter_search_pages_retries_once_then_skips_unparseable_page`); `ProxyHttpFetcher.fetch(force_proxy=True)` skips the direct attempt and falls back to direct when no proxy is available (`test_fetch_strategy.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)