### PR TITLE
Don't link new-match notifications to a deleted saved search

### DIFF
--- a/app/api/v1/notifications.py
+++ b/app/api/v1/notifications.py
@@ -6,11 +6,41 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth.dependencies import get_current_user, require_csrf
 from app.db.session import get_session
+from app.models.notification import Notification, NotificationType
 from app.models.user import User
 from app.notifications.repository import NotificationRepository
 from app.notifications.schemas import NotificationListOut, NotificationOut
+from app.saved_searches.repository import SavedSearchRepository
 
 router = APIRouter(prefix="/me/notifications", tags=["notifications"])
+
+
+def _referenced_saved_search_id(notification: Notification) -> uuid.UUID | None:
+    if notification.type != NotificationType.NEW_MATCH or not notification.payload:
+        return None
+    raw_id = notification.payload.get("saved_search_id")
+    if not isinstance(raw_id, str):
+        return None
+    try:
+        return uuid.UUID(raw_id)
+    except ValueError:
+        return None
+
+
+async def _to_out_list(notifications: list[Notification], session: AsyncSession) -> list[NotificationOut]:
+    """Batch-resolves which NEW_MATCH notifications point at a since-deleted saved search, so the
+    UI can render those without a (dead) link. One query for the whole page rather than one per row.
+    """
+    referenced_ids = {sid for n in notifications if (sid := _referenced_saved_search_id(n)) is not None}
+    existing_ids = await SavedSearchRepository(session).existing_ids(referenced_ids)
+
+    out = []
+    for notification in notifications:
+        item = NotificationOut.model_validate(notification)
+        referenced_id = _referenced_saved_search_id(notification)
+        item.saved_search_deleted = referenced_id is not None and referenced_id not in existing_ids
+        out.append(item)
+    return out
 
 
 @router.get("", response_model=NotificationListOut)
@@ -24,7 +54,7 @@ async def list_notifications(
     notifications = await repository.list_for_user(current_user.id, limit=limit, offset=offset)
     unread_count = await repository.count_unread(current_user.id)
     return NotificationListOut(
-        notifications=[NotificationOut.model_validate(n) for n in notifications],
+        notifications=await _to_out_list(notifications, session),
         unread_count=unread_count,
     )
 
@@ -44,4 +74,5 @@ async def mark_notification_read(
     if notification.read_at is None:
         notification.read_at = datetime.now(timezone.utc)
         await session.commit()
-    return NotificationOut.model_validate(notification)
+    (out,) = await _to_out_list([notification], session)
+    return out

--- a/app/notifications/schemas.py
+++ b/app/notifications/schemas.py
@@ -15,6 +15,9 @@ class NotificationOut(BaseModel):
     payload: dict | None
     read_at: datetime | None
     created_at: datetime
+    # True when this is a NEW_MATCH notification whose payload.saved_search_id no longer exists —
+    # lets the UI skip rendering a link that would just 404. Always False for other types.
+    saved_search_deleted: bool = False
 
 
 class NotificationListOut(BaseModel):

--- a/app/saved_searches/repository.py
+++ b/app/saved_searches/repository.py
@@ -33,6 +33,15 @@ class SavedSearchRepository:
         )
         return result.scalar_one()
 
+    async def existing_ids(self, ids: set[uuid.UUID]) -> set[uuid.UUID]:
+        """Which of `ids` still exist — lets callers tell a stale reference (e.g. a NEW_MATCH
+        notification's payload.saved_search_id, kept as plain JSON rather than a FK) from a live one.
+        """
+        if not ids:
+            return set()
+        result = await self.session.execute(select(SavedSearch.id).where(SavedSearch.id.in_(ids)))
+        return set(result.scalars().all())
+
     async def list_due(self, cutoff: datetime) -> list[SavedSearch]:
         """Enabled saved searches never refreshed, or last refreshed before `cutoff` — backs the
         periodic-refresh cron in app/scraping/scheduler.py (#26).

--- a/frontend/src/lib/notifications.ts
+++ b/frontend/src/lib/notifications.ts
@@ -9,6 +9,7 @@ export interface NotificationOut {
   payload: Record<string, unknown> | null
   read_at: string | null
   created_at: string
+  saved_search_deleted: boolean
 }
 
 export interface NotificationListOut {

--- a/frontend/src/notifications/format.ts
+++ b/frontend/src/notifications/format.ts
@@ -34,6 +34,7 @@ export function notificationDescription(notification: NotificationOut): string {
       const description = typeof payload.query_description === 'string' ? payload.query_description : ''
       const parts = [`${count} новых ${pluralizeListings(count)}`]
       if (updatedCount > 0) parts.push(`${updatedCount} обновилось`)
+      if (notification.saved_search_deleted) parts.push('поиск удалён')
       return `${parts.join(', ')}${description ? ` — ${description}` : ''}`
     }
     case 'price_drop':

--- a/frontend/src/pages/NotificationsPage.tsx
+++ b/frontend/src/pages/NotificationsPage.tsx
@@ -8,7 +8,11 @@ import { notificationDescription, notificationTitle } from '../notifications/for
 
 function notificationLinkTo(notification: NotificationOut): string | null {
   if (notification.listing_id) return `/listings/${notification.listing_id}`
-  if (notification.type === 'new_match' && typeof notification.payload?.saved_search_id === 'string') {
+  if (
+    notification.type === 'new_match' &&
+    !notification.saved_search_deleted &&
+    typeof notification.payload?.saved_search_id === 'string'
+  ) {
     return `/saved-searches/${notification.payload.saved_search_id}`
   }
   return null

--- a/tests/unit/test_notification_endpoints.py
+++ b/tests/unit/test_notification_endpoints.py
@@ -142,3 +142,67 @@ async def test_mark_notification_read_404_for_other_users_notification(client, e
     response = await client.post(f"/api/v1/me/notifications/{notification_id}/read", headers=_csrf_headers(client))
 
     assert response.status_code == 404
+
+
+async def test_opening_new_match_notification_after_saved_search_deleted(client, email_sender, session_factory):
+    """Saved search deleted, matched notification survives, flagged so the UI won't link to it —
+    the notification stays visible and markable-as-read, but is flagged with saved_search_deleted
+    so the UI knows not to render a (dead) link, and the underlying saved search still 404s directly.
+    """
+    await _register_and_login(client, email_sender)
+
+    create_response = await client.post(
+        "/api/v1/saved-searches",
+        json={"name": "Skoda alert", "query": {"make": "skoda"}},
+        headers=_csrf_headers(client),
+    )
+    assert create_response.status_code == 201
+    saved_search_id = create_response.json()["id"]
+
+    notification_id = await _seed_notification(
+        session_factory,
+        "notified@example.com",
+        payload={
+            "saved_search_id": saved_search_id,
+            "saved_search_name": "Skoda alert",
+            "new_listings_count": 3,
+            "updated_listings_count": 0,
+            "query_description": "Skoda",
+        },
+    )
+
+    delete_response = await client.delete(f"/api/v1/saved-searches/{saved_search_id}", headers=_csrf_headers(client))
+    assert delete_response.status_code == 204
+
+    list_response = await client.get("/api/v1/me/notifications")
+    assert list_response.status_code == 200
+    body = list_response.json()
+    assert len(body["notifications"]) == 1
+    assert body["notifications"][0]["payload"]["saved_search_id"] == saved_search_id
+    assert body["notifications"][0]["saved_search_deleted"] is True
+
+    read_response = await client.post(f"/api/v1/me/notifications/{notification_id}/read", headers=_csrf_headers(client))
+    assert read_response.status_code == 200
+    assert read_response.json()["saved_search_deleted"] is True
+
+    open_response = await client.get(f"/api/v1/saved-searches/{saved_search_id}")
+    assert open_response.status_code == 404
+
+
+async def test_new_match_notification_not_flagged_while_saved_search_exists(client, email_sender, session_factory):
+    await _register_and_login(client, email_sender)
+
+    create_response = await client.post(
+        "/api/v1/saved-searches",
+        json={"name": "Skoda alert", "query": {"make": "skoda"}},
+        headers=_csrf_headers(client),
+    )
+    saved_search_id = create_response.json()["id"]
+    await _seed_notification(
+        session_factory,
+        "notified@example.com",
+        payload={"saved_search_id": saved_search_id, "saved_search_name": "Skoda alert"},
+    )
+
+    list_response = await client.get("/api/v1/me/notifications")
+    assert list_response.json()["notifications"][0]["saved_search_deleted"] is False


### PR DESCRIPTION
## Summary
- Tested the scenario: user saves a search → gets a NEW_MATCH notification → deletes the saved search → opens the notification. The link used to 404 after navigating to `/saved-searches/{id}`.
- The API now flags `NEW_MATCH` notifications whose `payload.saved_search_id` no longer has a matching row (`saved_search_deleted`), computed with one batched existence check per page rather than per-row.
- The frontend uses that flag to skip rendering the notification as a link at all, and calls it out in the description text ("... поиск удалён").
- The old `/saved-searches/{id}` 404 handling (`OpenSavedSearchPage`) is left in place as a fallback for direct navigation (e.g. from an email link sent before the search was deleted).

## Test plan
- [x] `pytest` — full suite (206 tests) passes, including two new cases: flag is `true` right after the saved search is deleted, `false` while it still exists.
- [x] Manual verification in the browser (sqlite + throwaway Redis): registered a user, saved a search, seeded a NEW_MATCH notification, confirmed it rendered as a link — then deleted the saved search and confirmed the notification stayed in the list, marked read fine, and rendered with no link and the "поиск удалён" note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)