### PR TITLE
Sort search pages by renew_date_asc instead of basic

### DIFF
--- a/app/sources/polovniautomobili/adapter.py
+++ b/app/sources/polovniautomobili/adapter.py
@@ -78,7 +78,15 @@ class PolovniAutomobiliSource:
             )
 
     def build_search_url(self, query: SearchQuery, page: int = 1) -> str:
-        params: list[tuple[str, str]] = [("page", str(page)), ("sort", "basic")]
+        # "basic" (the site's default relevance-ish order) reshuffles as ads get posted/renewed
+        # while a long multi-page crawl is in flight, so the same ad can land on more than one
+        # page within a single run — each re-encounter gets upserted again and inflates
+        # ScrapeStats.listings_updated without a corresponding new row (see 2026-09-11/12
+        # FULL_SOURCE_REFRESH runs: listings_seen/listings_updated far exceeded the real row
+        # count in `listings`). renew_date_asc sorts stalest-renewed-first, so new posts and
+        # renews only ever get appended at the tail (a page we haven't reached yet) instead of
+        # prepended at page 1 — pages already crawled stay stable underneath us.
+        params: list[tuple[str, str]] = [("page", str(page)), ("sort", "renew_date_asc")]
         if query.make:
             params.append(("brand", query.make))
         for model in query.models or []:


### PR DESCRIPTION
## Summary
- Search pages were fetched with `sort=basic`, the site's default relevance-ish order, which reshuffles while a long multi-page crawl is in flight (new posts / bumped ads land on page 1). During a 3000-page FULL_SOURCE_REFRESH this caused the same ad to be seen on more than one page in a single run, inflating `listings_updated` well past the actual row count in `listings` (74288 seen / 65091 updated vs. 35647 rows).
- Switched to `sort=renew_date_asc`: stalest-renewed-first, verified live on the site (`renew_date_asc` = "Датуму објаве узлазно"). New posts and renews only ever append at the tail we haven't reached yet, so pages already crawled stay stable underneath us instead of shifting.

## Test plan
- [x] `pytest tests/unit/test_polovni_adapter.py` passes
- [ ] Run a FULL_SOURCE_REFRESH and confirm `len(seen_external_ids) == listings_seen` (no in-run duplicate encounters) and `listings_updated <= SELECT COUNT(*) FROM listings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)